### PR TITLE
Support more JavaScript runtimes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish to JSR
+on:
+  push:
+    tags:        
+      - '*'  # Publish every time a tag is pushed (unless it contains '/')
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish package
+        run: npx jsr publish

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,3 +33,21 @@ jobs:
 
       - name: Run integration tests
         run: deno test --allow-net integration.ts
+
+  test-bun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - name: Start MinIO for integration tests
+        run: docker run --name minio --detach -e MINIO_ROOT_USER=AKIA_DEV -e MINIO_ROOT_PASSWORD=secretkey -e MINIO_REGION_NAME=dev-region -p 9000:9000 -p 9001:9001 --entrypoint /bin/sh minio/minio:RELEASE.2021-10-23T03-28-24Z -c 'mkdir -p /data/dev-bucket && minio server --console-address ":9001" /data'
+      # TODO: can we get jsr to load the dependency versions from deno.jsonc?
+      - name: Install dependencies
+        run: bunx jsr add @std/io @std/assert
+      - name: Convert integration test from Deno to Bun test runner
+        run: '(echo -e ''import { test } from "bun:test";\nconst Deno = { test: ({fn}: {fn: () => void, name: string}) => test(fn) };''; cat integration.ts ) > integration-bun.ts'
+      - name: Run integration tests with bun
+        run: bun test ./integration-bun.ts

--- a/client.ts
+++ b/client.ts
@@ -124,6 +124,9 @@ const maximumPartSize = 5 * 1024 * 1024 * 1024;
 /** The maximum allowed object size for multi-part uploads. https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html */
 const maxObjectSize = 5 * 1024 * 1024 * 1024 * 1024;
 
+/**
+ * Client for connecting to S3-compatible object storage services.
+ */
 export class Client {
   readonly host: string;
   readonly port: number;
@@ -173,6 +176,7 @@ export class Client {
     this.region = params.region;
   }
 
+  /** Internal helper method to figure out which bucket name to use for a request */
   protected getBucketName(options: undefined | { bucketName?: string }): string {
     const bucketName = options?.bucketName ?? this.defaultBucket;
     if (bucketName === undefined || !isValidBucketName(bucketName)) {
@@ -185,7 +189,6 @@ export class Client {
 
   /**
    * Common code used for both "normal" requests and presigned UTL requests
-   * @param param0
    */
   private buildRequestOptions(options: {
     objectName: string;
@@ -620,6 +623,9 @@ export class Client {
     }
   }
 
+  /**
+   * Upload an object
+   */
   async putObject(
     objectName: string,
     streamOrData: ReadableStream<Uint8Array> | Uint8Array | string,
@@ -844,6 +850,7 @@ export class Client {
     };
   }
 
+  /** Check if a bucket exists */
   public async bucketExists(bucketName: string): Promise<boolean> {
     try {
       const objects = this.listObjects({ bucketName });
@@ -858,6 +865,7 @@ export class Client {
     }
   }
 
+  /** Create a new bucket */
   public async makeBucket(bucketName: string): Promise<void> {
     await this.makeRequest({
       method: "PUT",
@@ -867,6 +875,7 @@ export class Client {
     });
   }
 
+  /** Delete a bucket (must be empty) */
   public async removeBucket(bucketName: string): Promise<void> {
     await this.makeRequest({
       method: "DELETE",

--- a/mod.ts
+++ b/mod.ts
@@ -1,2 +1,11 @@
+/**
+ * @module
+ * A lightweight client for connecting to S3-compatible object storage services.
+ */
+
 export { Client as S3Client } from "./client.ts";
+
+/**
+ * Namespace for all errors that can be thrown by S3Client
+ */
 export * as S3Errors from "./errors.ts";


### PR DESCRIPTION
This runs the integration tests using [Bun](https://bun.sh/) as well as Deno.

Running the tests with Node.js is not feasible at the moment due to TypeScript usage and issues like https://github.com/TypeStrong/ts-node/issues/1997