### PR TITLE
docs: fix JSdoc for errors, rename error base class to S3Error

### DIFF
--- a/errors.ts
+++ b/errors.ts
@@ -1,50 +1,59 @@
+/**
+ * @module
+ * All the errors which can be thrown by this S3 client.
+ * Every error is a subclass of S3Error.
+ */
+
 import { parse as parseXML } from "./xml-parser.ts";
 
 /**
  * Base class for all errors raised by this S3 client.
  */
-export class DenoS3LiteClientError extends Error {
+export class S3Error extends Error {
   constructor(message: string) {
     super(message);
   }
 }
 
+// Preserve API compatibility with the old name:
+export const DenoS3LiteClientError = S3Error;
+
 /**
  * An argument or configuration parameter was invalid.
  */
-export class InvalidArgumentError extends DenoS3LiteClientError {}
+export class InvalidArgumentError extends S3Error {}
 
 /**
  * InvalidEndpointError is generated when an invalid end point value is
  * provided which does not follow domain standards.
  */
-export class InvalidEndpointError extends DenoS3LiteClientError {}
+export class InvalidEndpointError extends S3Error {}
 
 /**
  * InvalidBucketNameError is generated when an invalid bucket name is
  * provided which does not follow AWS S3 specifications.
  * http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
  */
-export class InvalidBucketNameError extends DenoS3LiteClientError {}
+export class InvalidBucketNameError extends S3Error {}
 
 /**
  * InvalidObjectNameError is generated when an invalid object name is
  * provided which does not follow AWS S3 specifications.
  * http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
  */
-export class InvalidObjectNameError extends DenoS3LiteClientError {}
+export class InvalidObjectNameError extends S3Error {}
 
 /** The request cannot be made without an access key to authenticate it */
-export class AccessKeyRequiredError extends DenoS3LiteClientError {}
+export class AccessKeyRequiredError extends S3Error {}
 
 /** The request cannot be made without a secret key to authenticate it */
-export class SecretKeyRequiredError extends DenoS3LiteClientError {}
+export class SecretKeyRequiredError extends S3Error {}
 
 /** The expiration time for the request is invalid */
-export class InvalidExpiryError extends DenoS3LiteClientError {}
+export class InvalidExpiryError extends S3Error {}
 
 /** Any error thrown by the server */
-export class ServerError extends DenoS3LiteClientError {
+export class ServerError extends S3Error {
   readonly statusCode: number;
   readonly code: string;
   readonly key: string | undefined;
@@ -68,6 +77,7 @@ export class ServerError extends DenoS3LiteClientError {
   }
 }
 
+/** Helper function to parse an error returned by the S3 server. */
 export async function parseServerError(response: Response): Promise<ServerError> {
   try {
     const xmlParsed = parseXML(await response.text());

--- a/mod.ts
+++ b/mod.ts
@@ -4,9 +4,4 @@
  */
 
 export { Client as S3Client } from "./client.ts";
-
-/**
- * @namespace
- * Namespace for all errors that can be thrown by S3Client
- */
 export * as S3Errors from "./errors.ts";


### PR DESCRIPTION
I hadn't figured out how to get a JSDoc comment on the `S3Errors` namespace, but I figured it out now I think.

I also renamed `DenoS3LiteClientError` to `S3Error` since you can use this with many different runtimes now. Old name is kept as an alias to avoid breaking changes.