### PR TITLE
Remove 'deps.ts' and 'deps-test.ts'

### DIFF
--- a/client.test.ts
+++ b/client.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "./deps-tests.ts";
+import { assertEquals } from "@std/assert/assert_equals";
 import { Client } from "./client.ts";
 
 Deno.test({

--- a/deps-tests.ts
+++ b/deps-tests.ts
@@ -1,4 +1,0 @@
-export { assert } from "@std/assert/assert";
-export { assertEquals } from "@std/assert/assert_equals";
-export { assertInstanceOf } from "@std/assert/assert_instance_of";
-export { assertRejects } from "@std/assert/assert_rejects";

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,0 @@
-export { Buffer } from "@std/io/buffer";

--- a/helpers.test.ts
+++ b/helpers.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "./deps-tests.ts";
+import { assertEquals } from "@std/assert/assert_equals";
 import { bin2hex, isValidPort, makeDateLong, makeDateShort, sha256digestHex } from "./helpers.ts";
 
 Deno.test({

--- a/integration.ts
+++ b/integration.ts
@@ -3,7 +3,10 @@
  *
  * See the README for instructions.
  */
-import { assert, assertEquals, assertInstanceOf, assertRejects } from "./deps-tests.ts";
+import { assert } from "@std/assert/assert";
+import { assertEquals } from "@std/assert/assert_equals";
+import { assertInstanceOf } from "@std/assert/assert_instance_of";
+import { assertRejects } from "@std/assert/assert_rejects";
 import { S3Client, S3Errors } from "./mod.ts";
 
 const config = {

--- a/signing.test.ts
+++ b/signing.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "./deps-tests.ts";
+import { assertEquals } from "@std/assert/assert_equals";
 import { bin2hex } from "./helpers.ts";
 import { _internalMethods as methods, presignV4, signV4 } from "./signing.ts";
 

--- a/transform-chunk-sizes.test.ts
+++ b/transform-chunk-sizes.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "./deps-tests.ts";
+import { assertEquals } from "@std/assert/assert_equals";
 import { TransformChunkSizes } from "./transform-chunk-sizes.ts";
 
 /**

--- a/transform-chunk-sizes.ts
+++ b/transform-chunk-sizes.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "./deps.ts";
+import { Buffer } from "@std/io/buffer";
 
 /**
  * This stream transform will buffer the data it receives until it has enough to form


### PR DESCRIPTION
These files don't provide any value now that Deno/JSR lets you specify dependency versions in `deno.jsonc`