### PR TITLE
Allow replacing metadata when copying an object, document metadata better

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Supported functionality:
 - Upload an object: `client.putObject("key", streamOrData, options)`
   - Can upload from a `string`, `Uint8Array`, or `ReadableStream`
   - Can split large uploads into multiple parts and uploads parts in parallel.
+  - Can set custom headers, ACLs, and other metadata on the new object (example below).
 - Copy an object: `client.copyObject({ sourceKey: "source", options }, "dest", options)`
   - Can copy between different buckets.
 - Delete an object: `client.deleteObject("key")`
@@ -121,6 +122,17 @@ const localOutFile = await Deno.open("test-out.txt", { write: true, createNew: t
 await result.body!.pipeTo(localOutFile.writable);
 // or instead of streaming, you can consume the whole file into memory by awaiting
 // result.text(), result.blob(), result.arrayBuffer(), or result.json()
+```
+
+Set ACLs, Content-Type, custom metadata, etc. during upload:
+
+```ts
+await s3client.putObject("key", streamOrData, {
+  metadata: {
+    "x-amz-acl": "public-read",
+    "x-amz-meta-custom": "value",
+  },
+})`
 ```
 
 For more examples, check out the tests in [`integration.ts`](./integration.ts)

--- a/client.ts
+++ b/client.ts
@@ -39,7 +39,6 @@ const metadataKeys = [
   "Content-Encoding",
   "Content-Language",
   "Expires",
-  "x-amz-acl",
   "x-amz-grant-full-control",
   "x-amz-grant-read",
   "x-amz-grant-read-acp",
@@ -66,7 +65,19 @@ const metadataKeys = [
  *
  * Custom keys should be like "x-amz-meta-..."
  */
-export type ObjectMetadata = { [K in typeof metadataKeys[number]]?: string } & { [key: string]: string };
+export type ObjectMetadata =
+  & {
+    "x-amz-acl"?:
+      | "private"
+      | "public-read"
+      | "public-read-write"
+      | "authenticated-read"
+      | "aws-exec-read"
+      | "bucket-owner-read"
+      | "bucket-owner-full-control";
+  }
+  & { [K in typeof metadataKeys[number]]?: string }
+  & { [customMetadata: `x-amz-meta-${string}`]: string };
 
 /** Response Header Overrides
  * These parameters can be used with an authenticated or presigned get object request, to
@@ -787,7 +798,7 @@ export class Client {
     // Also add in custom metadata
     response.headers.forEach((_value, key) => {
       if (key.startsWith("x-amz-meta-")) {
-        metadata[key] = response.headers.get(key) as string;
+        metadata[key as `x-amz-meta-${string}`] = response.headers.get(key) as string;
       }
     });
 


### PR DESCRIPTION
This PR:
* Closes #23 by adding a `metadata` option to `copyObject()` (now you can replace the metadata when copying an object)
* Updates the README to clarify how to set custom headers, ACLs, and other metadata. See #34.
* Adds stronger typing for some metadata fields like `x-amz-acl`