### PR TITLE
feat: export all types from client with S3 prefix

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -122,8 +122,10 @@ export interface CommonPrefix {
   prefix: string;
 }
 
+/**
+ * Additional properties provided by `statObject` compared to `listObjects`.
+ */
 export interface ObjectStatus extends S3Object {
-  // In addition to the data provided by "listObjects()", statObject() provides:
   versionId: string | null;
   metadata: ObjectMetadata;
 }

--- a/mod.ts
+++ b/mod.ts
@@ -3,5 +3,15 @@
  * A lightweight client for connecting to S3-compatible object storage services.
  */
 
-export { Client as S3Client, type ClientOptions as S3ClientOptions } from "./client.ts";
+export {
+  Client as S3Client,
+  type ClientOptions as S3ClientOptions,
+  type CommonPrefix as S3CommonPrefix,
+  type CopiedObjectInfo as S3CopiedObjectInfo,
+  type ObjectMetadata as S3ObjectMetadata,
+  type ObjectStatus as S3ObjectStatus,
+  type ResponseOverrideParams as S3ResponseOverrideParams,
+  type S3Object,
+  type UploadedObjectInfo as S3UploadedObjectInfo,
+} from "./client.ts";
 export * as S3Errors from "./errors.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -3,5 +3,5 @@
  * A lightweight client for connecting to S3-compatible object storage services.
  */
 
-export { Client as S3Client } from "./client.ts";
+export { Client as S3Client, type ClientOptions as S3ClientOptions } from "./client.ts";
 export * as S3Errors from "./errors.ts";


### PR DESCRIPTION
to make it possible to refer to the type of the constructor arguments from the outside without any "hacks".