### PR TITLE
Run tests with deno 2, fix formatting issues it finds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish to JSR
 on:
   push:
-    tags:        
-      - '*'  # Publish every time a tag is pushed (unless it contains '/')
+    tags:
+      - "*" # Publish every time a tag is pushed (unless it contains '/')
 
 jobs:
   publish:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Verify formatting
         run: deno fmt --check

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Supported functionality:
   <script type="module">
     import { S3Client } from "https://esm.sh/jsr/@bradenmacdonald/s3-lite-client@0.7.6";
     // Or:
-    const { S3Client } = await import('https://esm.sh/jsr/@bradenmacdonald/s3-lite-client@0.7.6');
+    const { S3Client } = await import("https://esm.sh/jsr/@bradenmacdonald/s3-lite-client@0.7.6");
   </script>
   ```
 
@@ -132,7 +132,7 @@ await s3client.putObject("key", streamOrData, {
     "x-amz-acl": "public-read",
     "x-amz-meta-custom": "value",
   },
-})
+});
 ```
 
 For more examples, check out the tests in [`integration.ts`](./integration.ts)


### PR DESCRIPTION
CI was running with Deno 1.x, but it's now time to use Deno 2. No meaningful changes to the code; just formatting fixes.