### PR TITLE
Remove runtime dependency (Buffer), bump stdlib version used in tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: docker run --name minio --detach -e MINIO_ROOT_USER=AKIA_DEV -e MINIO_ROOT_PASSWORD=secretkey -e MINIO_REGION_NAME=dev-region -p 9000:9000 -p 9001:9001 --entrypoint /bin/sh minio/minio:RELEASE.2021-10-23T03-28-24Z -c 'mkdir -p /data/dev-bucket && minio server --console-address ":9001" /data'
       # TODO: can we get jsr to load the dependency versions from deno.jsonc?
       - name: Install dependencies
-        run: bunx jsr add @std/streams@1.0.8 @std/assert@1.0.10
+        run: bunx jsr add @std/assert@1.0.10
       - name: Convert integration test from Deno to Bun test runner
         run: '(echo -e ''import { test } from "bun:test";\nconst Deno = { test: ({fn}: {fn: () => void, name: string}) => test(fn) };''; cat integration.ts ) > integration-bun.ts'
       - name: Run integration tests with bun

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: docker run --name minio --detach -e MINIO_ROOT_USER=AKIA_DEV -e MINIO_ROOT_PASSWORD=secretkey -e MINIO_REGION_NAME=dev-region -p 9000:9000 -p 9001:9001 --entrypoint /bin/sh minio/minio:RELEASE.2021-10-23T03-28-24Z -c 'mkdir -p /data/dev-bucket && minio server --console-address ":9001" /data'
       # TODO: can we get jsr to load the dependency versions from deno.jsonc?
       - name: Install dependencies
-        run: bunx jsr add @std/io@0.224 @std/assert@0.224
+        run: bunx jsr add @std/streams@1.0.8 @std/assert@1.0.10
       - name: Convert integration test from Deno to Bun test runner
         run: '(echo -e ''import { test } from "bun:test";\nconst Deno = { test: ({fn}: {fn: () => void, name: string}) => test(fn) };''; cat integration.ts ) > integration-bun.ts'
       - name: Run integration tests with bun

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # s3-lite-client
 
 This is a lightweight S3 client for Deno and other modern JavaScript runtimes. It is designed to offer all the key
-features you may need, with no dependencies outside of the Deno standard library. It does not use any Deno-specific
-features, so it should work with any runtime that supports the `fetch` API, web streams API, and ES modules (ESM).
+features you may need, with no dependencies. It does not use any Deno-specific features, so it should work with any
+runtime that supports the `fetch` API, web streams API, and ES modules (ESM).
 
 This client is 100% MIT licensed, and is derived from the excellent
 [MinIO JavaScript Client](https://github.com/minio/minio-js).

--- a/client.test.ts
+++ b/client.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert/equals";
 import { Client } from "./client.ts";
 
 Deno.test({

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,7 +7,6 @@
   },
   "lock": false,
   "imports": {
-    "@std/assert": "jsr:@std/assert@^1.0.10",
-    "@std/streams": "jsr:@std/streams@^1.0.8"
+    "@std/assert": "jsr:@std/assert@^1.0.10"
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,7 +7,7 @@
   },
   "lock": false,
   "imports": {
-    "@std/assert": "jsr:@std/assert@^0.224",
-    "@std/io": "jsr:@std/io@^0.224"
+    "@std/assert": "jsr:@std/assert@^1.0.10",
+    "@std/streams": "jsr:@std/streams@^1.0.8"
   }
 }

--- a/helpers.test.ts
+++ b/helpers.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert/equals";
 import { bin2hex, isValidPort, makeDateLong, makeDateShort, sha256digestHex } from "./helpers.ts";
 
 Deno.test({

--- a/integration.ts
+++ b/integration.ts
@@ -4,9 +4,9 @@
  * See the README for instructions.
  */
 import { assert } from "@std/assert/assert";
-import { assertEquals } from "@std/assert/assert-equals";
-import { assertInstanceOf } from "@std/assert/assert-instance-of";
-import { assertRejects } from "@std/assert/assert-rejects";
+import { assertEquals } from "@std/assert/equals";
+import { assertInstanceOf } from "@std/assert/instance-of";
+import { assertRejects } from "@std/assert/rejects";
 import { S3Client, S3Errors } from "./mod.ts";
 
 const config = {

--- a/signing.test.ts
+++ b/signing.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert/equals";
 import { bin2hex } from "./helpers.ts";
 import { _internalMethods as methods, presignV4, signV4 } from "./signing.ts";
 

--- a/transform-chunk-sizes.test.ts
+++ b/transform-chunk-sizes.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert/assert-equals";
+import { assertEquals } from "@std/assert/equals";
 import { TransformChunkSizes } from "./transform-chunk-sizes.ts";
 
 /**

--- a/transform-chunk-sizes.ts
+++ b/transform-chunk-sizes.ts
@@ -1,40 +1,41 @@
-import { Buffer } from "@std/streams/buffer";
-
 /**
  * This stream transform will buffer the data it receives until it has enough to form
  * a chunk of the specified size, then pass on the data in chunks of the specified size.
  */
 export class TransformChunkSizes extends TransformStream<Uint8Array, Uint8Array> {
-  constructor(outChunkSize: number) {
-    // This large buffer holds all the incoming data we receive until we reach at least outChunkSize, which we then pass on.
-    const buffer = new Buffer();
-    buffer.grow(outChunkSize);
-    const bufferWriter = buffer.writable.getWriter();
-    const bufferReader = buffer.readable.getReader({ mode: "byob" });
+  constructor(private readonly outChunkSize: number) {
+    // We'll keep one internal buffer of size outChunkSize,
+    // plus a current "offset" telling us how many bytes are in it.
+    let buffer = new Uint8Array(outChunkSize);
+    let offset = 0;
 
     super({
-      start() {}, // required
-      async transform(chunk, controller) {
-        await bufferWriter.write(chunk);
+      transform(chunk, controller) {
+        let pos = 0;
+        while (pos < chunk.length) {
+          // How many bytes remain to fill the buffer?
+          const needed = outChunkSize - offset;
+          // How many bytes we can copy from the incoming chunk this iteration
+          const toCopy = Math.min(needed, chunk.length - pos);
 
-        while (buffer.length >= outChunkSize) {
-          const outChunk = new Uint8Array(outChunkSize);
-          const readResult = await bufferReader.read(outChunk);
-          if (readResult.value === undefined || readResult.value?.length !== outChunkSize) {
-            throw new Error(
-              `Unexpectedly read ${
-                readResult.value?.length ?? 0
-              } bytes from transform buffer when trying to read ${outChunkSize} bytes.`,
-            );
+          // Copy from chunk into our internal buffer
+          buffer.set(chunk.subarray(pos, pos + toCopy), offset);
+          pos += toCopy;
+          offset += toCopy;
+
+          // If we've filled a chunk, push it to the output, then reset
+          if (offset === outChunkSize) {
+            controller.enqueue(buffer);
+            // We must not reuse that buffer, because it's still being read by the controller.
+            buffer = new Uint8Array(outChunkSize);
+            offset = 0;
           }
-          // Now "readResult.value" holds the next chunk of data (outChunk) - pass it on to the output:
-          controller.enqueue(readResult.value);
         }
       },
       flush(controller) {
-        if (buffer.length) {
-          // The buffer still contains some data, send it now even though it's smaller than the desired chunk size.
-          controller.enqueue(buffer.bytes());
+        // If anything remains in the buffer at the end, enqueue it.
+        if (offset > 0) {
+          controller.enqueue(buffer.subarray(0, offset));
         }
       },
     });


### PR DESCRIPTION
This library had one runtime dependency, which was [`Buffer` from `@std/io/buffer`](https://jsr.io/@std/io/doc/~/Buffer). But it seems like [that is never going to be stabilized](https://github.com/denoland/std/issues/5003), so I was considering switching to the very similar (but more complicated) [`Buffer` from `@std/streams/buffer`](https://jsr.io/@std/streams/doc/~/Buffer). But then I realized I could refactor this to not need any `Buffer` class at all 😎.

Now we are using the stable 1.x version of the JS Standard Library for test assertions, and have no runtime dependencies.