### PR TITLE
include headers option on exists check

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -413,7 +413,7 @@ export class Client {
   /**
    * Check if an object with the specified key exists.
    */
-  public async exists(objectName: string, options?: { bucketName?: string; versionId?: string }): Promise<boolean> {
+  public async exists(objectName: string, options?: { bucketName?: string; versionId?: string; headers?: Record<string, string>; }): Promise<boolean> {
     try {
       await this.statObject(objectName, options);
       return true;

--- a/client.ts
+++ b/client.ts
@@ -413,7 +413,10 @@ export class Client {
   /**
    * Check if an object with the specified key exists.
    */
-  public async exists(objectName: string, options?: { bucketName?: string; versionId?: string; headers?: Record<string, string>; }): Promise<boolean> {
+  public async exists(
+    objectName: string,
+    options?: { bucketName?: string; versionId?: string; headers?: Record<string, string> },
+  ): Promise<boolean> {
     try {
       await this.statObject(objectName, options);
       return true;


### PR DESCRIPTION
If the stat object command allows headers to be added to it, then the exists command should allow those same headers. 

The exact use case I'm seeing is with Tigris data storage, where to get a consistent read I need to add the header 'x-tigris-cas': 'true' or else I will get a cached result back.