### PR TITLE
fix: multipart upload signature mismatch with Digital Ocean Spaces

### DIFF
--- a/object-uploader.ts
+++ b/object-uploader.ts
@@ -91,14 +91,14 @@ export class ObjectUploader extends WritableStream<Uint8Array> {
             bucketName: bucketName,
             objectName: objectName,
             payload: chunk,
-          });
-          partPromise.then((response) => {
+          }).then((response) => {
             // In order to aggregate the parts together, we need to collect the etags.
             let etag = response.headers.get("etag") ?? "";
             if (etag) {
               etag = etag.replace(/^"/, "").replace(/"$/, "");
             }
             etags.push({ part: partNumber, etag });
+            return response;
           });
           partsPromises.push(partPromise);
         } catch (err) {

--- a/signing.test.ts
+++ b/signing.test.ts
@@ -149,6 +149,25 @@ Deno.test({
         "host;other-header;third-header\n" +
         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     );
+    assertEquals(
+      getCanonicalRequest(
+        "GET",
+        "/object123?" + new URLSearchParams({
+          "ሴ": "bar",
+          "unreserved": "-._~",
+        }).toString(),
+        new Headers(),
+        [],
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      ),
+      "GET\n" +
+        "/object123\n" +
+        "%E1%88%B4=bar&unreserved=-._~\n" +
+        "\n" +
+        "\n" +
+        "\n" +
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
   },
 });
 

--- a/signing.ts
+++ b/signing.ts
@@ -253,8 +253,12 @@ function getCanonicalRequest(
   if (requestQuery) {
     requestQuery = requestQuery
       .split("&")
-      .sort()
-      .map((element) => element.indexOf("=") === -1 ? element + "=" : element)
+      .map((element) => {
+        const [key, val] = element.split("=", 2);
+        // The input is assumed to be encoded, so we need to decode it first.
+        return awsUriEncode(decodeURIComponent(key)) + "=" + awsUriEncode(decodeURIComponent(val || ""));
+      })
+      .sort() // sort after encoding
       .join("&");
   } else {
     requestQuery = "";


### PR DESCRIPTION
- Fixed query parameter encoding in getCanonicalRequest to properly handle special characters
- Improved error handling in multipart uploads by chaining promises correctly
- Added unit test for query parameter normalization with special characters

Resolves signature mismatch errors when uploadId contains characters like "~"

fixes #67 