### PR TITLE
fix: compatibility with std lib changes in TypeScript 5.7 & 5.9

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -7,6 +7,7 @@ import {
   makeDateLong,
   sanitizeETag,
   sha256digestHex,
+  type Uint8Array_,
 } from "./helpers.ts";
 import { ObjectUploader } from "./object-uploader.ts";
 import { presignPostV4, presignV4, signV4 } from "./signing.ts";
@@ -309,7 +310,7 @@ export class Client {
     /** The status code we expect the server to return */
     statusCode?: number;
     /** The request body */
-    payload?: Uint8Array | string;
+    payload?: Uint8Array_ | string;
     /**
      * returnBody: We have to read the request body to avoid leaking resources.
      * So by default this method will read and ignore the body. If you actually

--- a/helpers.ts
+++ b/helpers.ts
@@ -1,3 +1,11 @@
+/**
+ * For TypeScript 5.7+ we have to write `Uint8Array<ArrayBuffer>` instead of
+ * `Uint8Array` or we'll get type errors in various places where arrays based
+ * on SharedArrayBuffer are not allowed. This type alias will work both pre-
+ * and post- TypeScript 5.7. Yes this is annoying.
+ */
+export type Uint8Array_ = ReturnType<Uint8Array["slice"]>;
+
 export function isValidPort(port: number) {
   // verify if port is a number.
   if (typeof port !== "number" || isNaN(port)) {
@@ -115,7 +123,7 @@ export function getScope(region: string, date: Date) {
   return `${makeDateShort(date)}/${region}/s3/aws4_request`;
 }
 
-export async function sha256digestHex(data: Uint8Array | string) {
+export async function sha256digestHex(data: Uint8Array_ | string) {
   if (!(data instanceof Uint8Array)) {
     data = new TextEncoder().encode(data);
   }

--- a/object-uploader.ts
+++ b/object-uploader.ts
@@ -1,5 +1,5 @@
 import type { Client, ObjectMetadata, UploadedObjectInfo } from "./client.ts";
-import { getVersionId, sanitizeETag } from "./helpers.ts";
+import { getVersionId, sanitizeETag, type Uint8Array_ } from "./helpers.ts";
 import { parse as parseXML } from "./xml-parser.ts";
 
 // Metadata headers that must be included in each part of a multi-part upload
@@ -21,7 +21,7 @@ const multipartTagAlongMetadataKeys = [
  * will decide based on the size of the first chunk whether it is doing a
  * single-request upload or a multi-part upload.
  */
-export class ObjectUploader extends WritableStream<Uint8Array> {
+export class ObjectUploader extends WritableStream<Uint8Array_> {
   public readonly getResult: () => UploadedObjectInfo;
 
   constructor({ client, bucketName, objectName, partSize, metadata }: {

--- a/signing.ts
+++ b/signing.ts
@@ -1,5 +1,5 @@
 import * as errors from "./errors.ts";
-import { bin2hex, getScope, makeDateLong, makeDateShort, sha256digestHex } from "./helpers.ts";
+import { bin2hex, getScope, makeDateLong, makeDateShort, sha256digestHex, type Uint8Array_ } from "./helpers.ts";
 
 const signV4Algorithm = "AWS4-HMAC-SHA256";
 
@@ -295,7 +295,7 @@ async function getSigningKey(
   date: Date,
   region: string,
   secretKey: string,
-): Promise<Uint8Array> {
+): Promise<Uint8Array_> {
   const dateLine = makeDateShort(date);
   const hmac1 = await sha256hmac("AWS4" + secretKey, dateLine);
   const hmac2 = await sha256hmac(hmac1, region);
@@ -315,9 +315,9 @@ function getCredential(accessKey: string, region: string, requestDate: Date) {
  * @returns
  */
 async function sha256hmac(
-  secretKey: Uint8Array | string,
-  data: Uint8Array | string,
-): Promise<Uint8Array> {
+  secretKey: Uint8Array_ | string,
+  data: Uint8Array_ | string,
+): Promise<Uint8Array_> {
   const enc = new TextEncoder();
   const keyObject = await crypto.subtle.importKey(
     "raw", // raw format of the key - should be Uint8Array
@@ -385,7 +385,7 @@ export async function presignPostV4(request: {
     "X-Amz-Credential": credential,
     "X-Amz-Date": iso8601Date,
     "key": request.objectKey,
-    ...request.fields || {},
+    ...request.fields,
   };
 
   // Build policy document


### PR DESCRIPTION
[These changes in TypeScript 5.7](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/#typedarrays-are-now-generic-over-arraybufferlike) and perhaps also the [related changes in 5.9](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#lib.d.ts-changes) cause a bunch of errors when type checking this repo.

Example:

```
TS2345 [ERROR]: Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'BufferSource'.
  Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'ArrayBufferView<ArrayBuffer>'.
    Types of property 'buffer' are incompatible.
      Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
        Type 'SharedArrayBuffer' is missing the following properties from type 'ArrayBuffer': resizable, resize, detached, transfer, transferToFixedLength
    data instanceof Uint8Array ? data : enc.encode(data),
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    at s3-lite-client/signing.ts:332:5
```

This PR fixes the issue with a backwards-compatible workaround borrowed from https://github.com/denoland/std/blob/8df6974b198bca650664c6b5286e365bd9f01946/bytes/_types.ts#L11