### PR TITLE
fix: JSR publish via npx failed due to outdated @types/node

### DIFF
--- a/.github/workflows/check-bundle-size.yml
+++ b/.github/workflows/check-bundle-size.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
 
       - name: Publish package
-        run: npx jsr publish
+        run: deno publish

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -34,11 +34,14 @@ jobs:
       - name: Run integration tests
         run: deno test --allow-net integration.ts
 
+      - name: Check JSR publish eligibility
+        run: deno publish --dry-run
+
   test-bun:
     runs-on: ubuntu-latest
     steps:
       - name: Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -56,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x


### PR DESCRIPTION
So we'll use deno instead of node to publish it.



Error details:

```

Run npx jsr publish
npm warn exec The following package was not found and will be installed: jsr@0.13.5
Downloading JSR release binary...
Download completed
Check file:///home/runner/work/s3-lite-client/s3-lite-client/mod.ts
TS2322 [ERROR]: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'string | Uint8Array<ArrayBuffer> | undefined'.
  Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'Uint8Array<ArrayBuffer>'.
    Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
      Type 'SharedArrayBuffer' is missing the following properties from type 'ArrayBuffer': resizable, resize, detached, transfer, transferToFixedLength
        payload = new TextEncoder().encode(payload);
        ~~~~~~~
    at file:///home/runner/work/s3-lite-client/s3-lite-client/client.ts:332:9
```