### PR TITLE
fix: make bucket name validation less strict (allow uppercase)

### DIFF
--- a/helpers.test.ts
+++ b/helpers.test.ts
@@ -31,9 +31,9 @@ Deno.test({
         "ab", // too short
         "has_underscore", // no underscores
         "test..bar", // double periods
-        "192.168.5.4", // looks like an IP address
-        "propellane-possesses-omniphilic-reactivity-anions-and-radicals-add-towards-the-interbridgehead-bond", // too long
-        "-hyphen-",
+        // too long:
+        "propellane-possesses-omniphilic-reactivity-anions-and-radicals-add-towards-the-interbridgehead-bond-because-the-tridimensional-vacuum-constant-is-weaker-in-the-magnetic-flux-from-the-pseudo-electromagnetic-field-generated-by-the-subspace-distortion-of-the-integrated-hypercapacitor",
+        "-hyphen-", // must start/end with letters/numbers
       ] as unknown as string[]
     ) {
       await t.step({
@@ -47,6 +47,7 @@ Deno.test({
         "bucket",
         "bucket-23",
         "test.bucket.com",
+        "Capitalized.Backblaze.Bucket",
       ] as unknown as string[]
     ) {
       await t.step({

--- a/helpers.ts
+++ b/helpers.ts
@@ -17,32 +17,32 @@ export function isValidPort(port: number) {
 
 /**
  * Validate a bucket name.
- * http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+ *
+ * This is pretty minimal, general validation. We let the remote
+ * S3 server do detailed validation.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
  */
-export function isValidBucketName(bucket: string) {
+export function isValidBucketName(bucket: string): boolean {
   if (typeof bucket !== "string") {
     return false;
   }
-
-  // bucket length should be less than and no more than 63
-  // characters long.
-  if (bucket.length < 3 || bucket.length > 63) {
+  // Generally the bucket name length limit is 63, but
+  // "Before March 1, 2018, buckets created in the US East (N. Virginia)
+  //  Region could have names that were up to 255 characters long"
+  if (bucket.length > 255) {
     return false;
   }
-  // bucket with successive periods is invalid.
+  // "Bucket names must not contain two adjacent periods."
   if (bucket.includes("..")) {
     return false;
   }
-  // bucket cannot have ip address style.
-  if (bucket.match(/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/)) {
-    return false;
-  }
-  // bucket should begin with alphabet/number and end with alphabet/number,
-  // with alphabet/number/.- in the middle.
-  if (bucket.match(/^[a-z0-9][a-z0-9.-]+[a-z0-9]$/)) {
-    return true;
-  }
-  return false;
+  // "Bucket names must begin and end with a letter or number."
+  // "Bucket names can consist only of lowercase letters, numbers,
+  //  periods (.), and hyphens (-)."
+  // -> Most S3 servers require lowercase bucket names but some allow
+  // uppercase (Backblaze, AWS us-east buckets created before 2018)
+  return Boolean(bucket.match(/^[a-zA-Z0-9][a-zA-Z0-9.-]+[a-zA-Z0-9]$/));
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/bradenmacdonald/s3-lite-client/issues/76 .

The MinIO code that this library was originally based on does a _lot_ of client-side validation of inputs. But the server is going to be validating everything anyways, so I think it's better to do less validation in the client and lean more heavily on the server. Especially in cases where different S3 servers have different rules/implementations. This is one such case: Backblaze B2 allows uppercase bucket names, and even AWS did in one region before 2018, so we shouldn't require bucket names to be lowercase on the client side of things.