### PR TITLE
feat: allow listing keys page by page with continuation tokens

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -583,7 +583,8 @@ export class Client {
   /**
    * List objects in the bucket, optionally filtered by the given key prefix.
    *
-   * This returns a flat list; use listObjectsGrouped() for more advanced behavior.
+   * This returns a flat list; use `listObjectsGrouped()` for more advanced behavior,
+   * such as grouping or pagination.
    */
   public async *listObjects(
     options: {
@@ -611,13 +612,28 @@ export class Client {
   }
 
   /**
-   * List objects in the bucket, grouped based on the specified "delimiter".
+   * List objects in the bucket, optionally grouped based on the specified "delimiter".
    *
-   * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html
+   * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html for
+   * details on using a delimiter.
+   *
+   * To retrieve results page by page with this generator, you cannot use `for await`.
+   * Instead, call this with a helper function like the following:
+   * ```
+   * async function retrievePage(continuationToken?: string) {
+   *   const pageSize = 10;
+   *   const iterator = client.listObjectsGrouped({ continuationToken, pageSize, maxResults: pageSize });
+   *   const page: S3Object[] = [];
+   *   let r: IteratorResult<S3Object | S3CommonPrefix, string | undefined>;
+   *   while (!(r = await iterator.next()).done) { if (r.value.type === "Object") page.push(r.value); }
+   *   // Once the iterator is 'done', r.value will have the continuation token.
+   *   return { page, continuationToken: r.value };
+   * }
+   * ```
    */
   public async *listObjectsGrouped(
     options: {
-      delimiter: string;
+      delimiter?: string;
       prefix?: string;
       bucketName?: string;
       /** Don't return more than this many results in total. Default: unlimited. */
@@ -625,13 +641,14 @@ export class Client {
       /**
        * How many keys to retrieve per HTTP request (default: 1000)
        * This is a maximum; sometimes fewer keys will be returned.
-       * This will not affect the shape of the result, just its efficiency.
        */
       pageSize?: number;
+      /** Retrieve results from later pages using this continuation token. */
+      continuationToken?: string;
     },
-  ): AsyncGenerator<S3Object | CommonPrefix, void, undefined> {
+  ): AsyncGenerator<S3Object | CommonPrefix, string | undefined, undefined> {
     const bucketName = this.getBucketName(options);
-    let continuationToken = "";
+    let continuationToken = options.continuationToken ?? "";
     const pageSize = options.pageSize ?? 1_000;
     if (pageSize < 1 || pageSize > 1_000) {
       throw new errors.InvalidArgumentError("pageSize must be between 1 and 1,000.");
@@ -652,7 +669,7 @@ export class Client {
         query: {
           "list-type": "2",
           prefix: options.prefix ?? "",
-          delimiter: options.delimiter,
+          delimiter: options.delimiter ?? "",
           "max-keys": String(maxKeys),
           ...(continuationToken ? { "continuation-token": continuationToken } : {}),
         },
@@ -707,6 +724,11 @@ export class Client {
           throw new Error("Unexpectedly missing continuation token, but server said there are more results.");
         }
         continuationToken = nextContinuationToken;
+        if (options.maxResults && resultCount >= options.maxResults) {
+          // We returned the maximum number of results.
+          // Don't retrieve any more results for now; stop iteration and return the continuationToken.
+          return continuationToken;
+        }
       } else {
         // That's it, no more results.
         return;

--- a/integration.ts
+++ b/integration.ts
@@ -7,7 +7,7 @@ import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
 import { assertInstanceOf } from "@std/assert/instance-of";
 import { assertRejects } from "@std/assert/rejects";
-import { S3Client, S3Errors } from "./mod.ts";
+import { S3Client, type S3CommonPrefix, S3Errors, type S3Object } from "./mod.ts";
 
 const config = {
   endPoint: "http://localhost:9000",
@@ -439,6 +439,123 @@ Deno.test({
     assertEquals(results[3].prefix, `${prefix}subpath-2/`);
     assert(results[4].type === "Object");
     assertEquals(results[4].key, `${prefix}x-file.txt`);
+  },
+});
+
+Deno.test({
+  name: "listObjectsGrouped() can retrieve results page by page (partial final page)",
+  fn: async () => {
+    const prefix = "list-objects-test-4/";
+    // Create folder1 with 25 entries
+    for (let i = 1; i <= 25; i++) {
+      await client.putObject(`${prefix}folder1/file-${i.toString().padStart(3, "0")}.txt`, `file ${i} contents`);
+    }
+
+    // Retrieve the first page only:
+    async function retrievePage(continuationToken?: string) {
+      const iterator = client.listObjectsGrouped({ continuationToken, prefix, pageSize: 10, maxResults: 10 });
+      const page: S3Object[] = [];
+      let r: IteratorResult<S3Object | S3CommonPrefix, string | undefined>;
+      while (!(r = await iterator.next()).done) if (r.value.type === "Object") page.push(r.value);
+      return { page, continuationToken: r.value };
+    }
+
+    const page1 = await retrievePage();
+    assertEquals(page1.page.map((k) => k.key), [
+      `${prefix}folder1/file-001.txt`,
+      `${prefix}folder1/file-002.txt`,
+      `${prefix}folder1/file-003.txt`,
+      `${prefix}folder1/file-004.txt`,
+      `${prefix}folder1/file-005.txt`,
+      `${prefix}folder1/file-006.txt`,
+      `${prefix}folder1/file-007.txt`,
+      `${prefix}folder1/file-008.txt`,
+      `${prefix}folder1/file-009.txt`,
+      `${prefix}folder1/file-010.txt`,
+    ]);
+
+    const page2 = await retrievePage(page1.continuationToken);
+    assertEquals(page2.page.map((k) => k.key), [
+      `${prefix}folder1/file-011.txt`,
+      `${prefix}folder1/file-012.txt`,
+      `${prefix}folder1/file-013.txt`,
+      `${prefix}folder1/file-014.txt`,
+      `${prefix}folder1/file-015.txt`,
+      `${prefix}folder1/file-016.txt`,
+      `${prefix}folder1/file-017.txt`,
+      `${prefix}folder1/file-018.txt`,
+      `${prefix}folder1/file-019.txt`,
+      `${prefix}folder1/file-020.txt`,
+    ]);
+
+    const page3 = await retrievePage(page2.continuationToken);
+    assertEquals(page3.page.map((k) => k.key), [
+      `${prefix}folder1/file-021.txt`,
+      `${prefix}folder1/file-022.txt`,
+      `${prefix}folder1/file-023.txt`,
+      `${prefix}folder1/file-024.txt`,
+      `${prefix}folder1/file-025.txt`,
+    ]);
+    assertEquals(page3.continuationToken, undefined);
+
+    // Cleanup:
+    for await (const r of client.listObjects({ prefix })) {
+      await client.deleteObject(r.key);
+    }
+  },
+});
+
+Deno.test({
+  name: "listObjectsGrouped() can retrieve results page by page (full final page)",
+  fn: async () => {
+    const prefix = "list-objects-test-5/";
+    // Create folder1 with 20 entries
+    for (let i = 1; i <= 20; i++) {
+      await client.putObject(`${prefix}folder1/file-${i.toString().padStart(3, "0")}.txt`, `file ${i} contents`);
+    }
+
+    // Retrieve the first page only:
+    async function retrievePage(continuationToken?: string) {
+      const iterator = client.listObjectsGrouped({ continuationToken, prefix, pageSize: 10, maxResults: 10 });
+      const page: S3Object[] = [];
+      let r: IteratorResult<S3Object | S3CommonPrefix, string | undefined>;
+      while (!(r = await iterator.next()).done) if (r.value.type === "Object") page.push(r.value);
+      return { page, continuationToken: r.value };
+    }
+
+    const page1 = await retrievePage();
+    assertEquals(page1.page.map((k) => k.key), [
+      `${prefix}folder1/file-001.txt`,
+      `${prefix}folder1/file-002.txt`,
+      `${prefix}folder1/file-003.txt`,
+      `${prefix}folder1/file-004.txt`,
+      `${prefix}folder1/file-005.txt`,
+      `${prefix}folder1/file-006.txt`,
+      `${prefix}folder1/file-007.txt`,
+      `${prefix}folder1/file-008.txt`,
+      `${prefix}folder1/file-009.txt`,
+      `${prefix}folder1/file-010.txt`,
+    ]);
+
+    const page2 = await retrievePage(page1.continuationToken);
+    assertEquals(page2.page.map((k) => k.key), [
+      `${prefix}folder1/file-011.txt`,
+      `${prefix}folder1/file-012.txt`,
+      `${prefix}folder1/file-013.txt`,
+      `${prefix}folder1/file-014.txt`,
+      `${prefix}folder1/file-015.txt`,
+      `${prefix}folder1/file-016.txt`,
+      `${prefix}folder1/file-017.txt`,
+      `${prefix}folder1/file-018.txt`,
+      `${prefix}folder1/file-019.txt`,
+      `${prefix}folder1/file-020.txt`,
+    ]);
+    assertEquals(page2.continuationToken, undefined);
+
+    // Cleanup:
+    for await (const r of client.listObjects({ prefix })) {
+      await client.deleteObject(r.key);
+    }
   },
 });
 


### PR DESCRIPTION
Closes #78 . It's not very easy to use, but it now allows retrieving list results page by page without any major changes to the API.