### PR TITLE
feat: allow signing extra headers into pre-signed URLs (extraHeaders)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ supports the `fetch` API, web streams API, and ES modules (ESM).
 - Browser:
   ```html
   <script type="module">
-    import { S3Client } from "https://esm.sh/jsr/@bradenmacdonald/s3-lite-client@0.9.6";
-    // Or:
-    const { S3Client } = await import("https://esm.sh/jsr/@bradenmacdonald/s3-lite-client@0.9.6");
+  import { S3Client } from "https://esm.sh/jsr/@bradenmacdonald/s3-lite-client@0.9.6";
+  // Or:
+  const { S3Client } = await import("https://esm.sh/jsr/@bradenmacdonald/s3-lite-client@0.9.6");
   </script>
   ```
 

--- a/client.test.ts
+++ b/client.test.ts
@@ -307,3 +307,30 @@ Deno.test({
     });
   },
 });
+
+Deno.test({
+  name: "getPresignedUrl() can include extra headers in the signature",
+  fn: async () => {
+    const client = new Client({
+      endPoint: "https://s3.example.com",
+      region: "auto",
+      bucket: "test-bucket",
+      accessKey: "test-access-key",
+      secretKey: "test-secret-key",
+    });
+    const requestDate = new Date("2026-07-23T12:00:00.000Z");
+    const conditionalUrl = new URL(
+      await client.getPresignedUrl("PUT", "file.txt", {
+        requestDate,
+        extraHeaders: { "If-None-Match": "*" },
+      }),
+    );
+    const unconditionalUrl = new URL(await client.getPresignedUrl("PUT", "file.txt", { requestDate }));
+
+    // The extra header must be listed in the signed headers:
+    assertEquals(conditionalUrl.searchParams.get("X-Amz-SignedHeaders")?.split(";"), ["host", "if-none-match"]);
+    assertEquals(unconditionalUrl.searchParams.get("X-Amz-SignedHeaders"), "host");
+    // And it must change the signature:
+    assert(conditionalUrl.searchParams.get("X-Amz-Signature") !== unconditionalUrl.searchParams.get("X-Amz-Signature"));
+  },
+});

--- a/client.ts
+++ b/client.ts
@@ -526,8 +526,18 @@ export class Client {
   getPresignedUrl(
     method: "GET" | "PUT" | "HEAD" | "DELETE",
     objectName: string,
-    options: { bucketName?: string; parameters?: Record<string, string>; expirySeconds?: number; requestDate?: Date } =
-      {},
+    options: {
+      bucketName?: string;
+      parameters?: Record<string, string>;
+      expirySeconds?: number;
+      requestDate?: Date;
+      /**
+       * Additional headers to include in the signature (advanced usage), e.g. `{ "If-None-Match": "*" }` to make a
+       * conditional write that cannot overwrite an existing object. Whoever uses the resulting pre-signed URL must
+       * send these exact headers along with the request, or it will be rejected.
+       */
+      extraHeaders?: Record<string, string>;
+    } = {},
   ): Promise<string> {
     if (!this.accessKey) {
       throw new errors.AccessKeyRequiredError();
@@ -539,6 +549,7 @@ export class Client {
       objectName,
       bucketName: options.bucketName,
       query: options.parameters,
+      headers: new Headers(options.extraHeaders),
     });
     const requestDate = options.requestDate ?? new Date();
     const expirySeconds = options.expirySeconds ?? 24 * 60 * 60 * 7; // default expiration is 7 days in seconds.

--- a/integration.ts
+++ b/integration.ts
@@ -296,6 +296,37 @@ Deno.test({
 });
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// getPresignedUrl() with extraHeaders
+
+Deno.test({
+  name: "getPresignedUrl() can sign extra headers, e.g. If-None-Match for a conditional write",
+  fn: async () => {
+    const key = "test-presigned-conditional.txt";
+    await client.deleteObject(key);
+    const presignedUrl = await client.getPresignedUrl("PUT", key, { extraHeaders: { "If-None-Match": "*" } });
+
+    // A request that doesn't send the signed header is rejected (the exact status code varies by S3 implementation):
+    const missingHeader = await fetch(presignedUrl, { method: "PUT", body: "first version" });
+    await missingHeader.body?.cancel();
+    assert(missingHeader.status >= 400);
+    assertEquals(await client.exists(key), false);
+
+    // The first conditional write succeeds, because the object doesn't exist yet:
+    const putVersion = (body: string) =>
+      fetch(presignedUrl, { method: "PUT", body, headers: { "If-None-Match": "*" } });
+    const first = await putVersion("first version");
+    await first.body?.cancel();
+    assertEquals(first.status, 200);
+
+    // The second conditional write fails with 412 Precondition Failed, because the object now exists:
+    const second = await putVersion("second version");
+    await second.body?.cancel();
+    assertEquals(second.status, 412);
+    assertEquals(await client.getObject(key).then((r) => r.text()), "first version");
+  },
+});
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // presignedGetObject()
 
 Deno.test({


### PR DESCRIPTION
Adds an `extraHeaders` option to `getPresignedUrl()`, so callers can include additional headers in the SigV4 signature (`X-Amz-SignedHeaders`).

## Motivation

S3, MinIO, and R2 support conditional writes: a `PUT` with `If-None-Match: *` fails with `412 Precondition Failed` if the object already exists. To use this from a pre-signed URL, the header has to be part of the signature — today `getPresignedUrl()` only signs `host`, so there is no way to hand a client an upload URL that can't overwrite an existing object.

This was requested in the discussion on #58 ("would like to pass per-request headers into `getPresignedUrl` as well"), but that PR's author preferred to keep it out of scope there since they don't use `getPresignedUrl`. This PR covers just the pre-signed part, following the API direction suggested in the #58 review:

- named `extraHeaders`, documented as advanced usage;
- no overlap with `metadata` to worry about, since pre-signed URLs have no metadata parameter.

## What's included

- `extraHeaders?: Record<string, string>` on `getPresignedUrl()`, passed into the existing request-builder/signing path (no signing changes needed — `presignV4` already signs whatever headers it's given).
- A unit test asserting the extra header lands in `X-Amz-SignedHeaders` and changes the signature, and that the default stays `host` only.
- An integration test doing a real conditional write round-trip against MinIO (the same `RELEASE.2025-02-28T09-55-16Z` used in CI): a request without the signed header is rejected, the first conditional `PUT` succeeds, the second fails with `412`, and the first version's content is preserved.

`deno fmt --check`, `deno lint`, `deno test`, and `deno test --allow-net integration.ts` all pass locally.
