### PR TITLE
fix: more consistent encoding of spaces

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -289,7 +289,8 @@ export class Client {
     const headers = options.headers ?? new Headers();
     headers.set("host", host);
     const queryAsString = typeof options.query === "object"
-      ? new URLSearchParams(options.query).toString().replace("+", "%20") // Signing requires spaces become %20, never +
+      // Signing requires spaces become %20, never + (and S3 does not form-decode '+' back into a space)
+      ? new URLSearchParams(options.query).toString().replaceAll("+", "%20")
       : (options.query);
 
     const basePath = this.pathStyle

--- a/integration.ts
+++ b/integration.ts
@@ -237,6 +237,23 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "getObject() can specify response params",
+  fn: async () => {
+    const contents = "This is the contents of the file. 😎";
+    await client.putObject("test-get3.txt", contents);
+
+    const responseParams = {
+      "response-content-disposition": `attachment; filename="my file.txt"`, // test multiple spaces
+      "response-cache-control": "public, max-age=100",
+    };
+    const response = await client.getObject("test-get3.txt", { responseParams });
+    assertEquals(await response.text(), contents);
+    assertEquals(response.headers.get("Content-Disposition"), `attachment; filename="my file.txt"`);
+    assertEquals(response.headers.get("Cache-Control"), "public, max-age=100");
+  },
+});
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // non-ascii characters in URLs
 
@@ -335,13 +352,17 @@ Deno.test({
     const contents = "This is the contents of the file. 👻"; // Throw in an Emoji to ensure Unicode round-trip is working.
     await client.putObject("test-presigned.cstm", contents);
     const presignedUrl = await client.presignedGetObject("test-presigned.cstm", {
-      // Also try overriding a response parameter
-      responseParams: { "response-content-type": "custom/content-type" },
+      // Also try overriding response parameters
+      responseParams: {
+        "response-content-type": "custom/content-type",
+        "response-content-disposition": `attachment; filename="my file.txt"`,
+      },
     });
     // Now use the pre-signed URL to download the file
     const response = await fetch(presignedUrl);
     assertEquals(await response.text(), contents);
-    assertEquals(await response.headers.get("Content-Type"), "custom/content-type");
+    assertEquals(response.headers.get("Content-Type"), "custom/content-type");
+    assertEquals(response.headers.get("Content-Disposition"), `attachment; filename="my file.txt"`);
   },
 });
 

--- a/signing.test.ts
+++ b/signing.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "@std/assert/equals";
+import { assertStringIncludes } from "@std/assert/string-includes";
 import { bin2hex } from "./helpers.ts";
 import { _internalMethods as methods, presignPostV4, presignV4, signV4 } from "./signing.ts";
 
@@ -80,6 +81,30 @@ Deno.test({
       urlActual,
       "https://localhost:9000/bucket/object?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA_TEST_ACCESS_KEY%2F20211026%2Fca-central-1%2Fs3%2Faws4_request&X-Amz-Date=20211026T180728Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=def1ddcb522798495b6b72970222eceef7d6070f131d12d819b81fb308503dfe",
     );
+  },
+});
+
+Deno.test({
+  name: "presignV4 - encodes spaces as %20 in every query parameter, not just the first",
+  fn: async () => {
+    const urlActual = await presignV4({
+      protocol: "https:",
+      method: "GET",
+      path: "/bucket/object?p1=one%20space&p2=two%20spaces%20here",
+      headers: new Headers({
+        host: "localhost:9000",
+      }),
+      accessKey: "AKIA_TEST_ACCESS_KEY",
+      secretKey: "ThisIsTheSecret",
+      region: "ca-central-1",
+      date: new Date("2021-10-26T18:07:28.492Z"),
+      expirySeconds: 60 * 60,
+    });
+    // S3 does not form-decode query strings, so a literal '+' is delivered to the server as '+' and
+    // not as a space. Every parameter must therefore use %20, not only whichever one comes first.
+    assertEquals(urlActual.includes("+"), false, "Presigned URL should not contain any unencoded '+' character");
+    assertStringIncludes(urlActual, "p1=one%20space");
+    assertStringIncludes(urlActual, "p2=two%20spaces%20here");
   },
 });
 

--- a/signing.ts
+++ b/signing.ts
@@ -106,7 +106,8 @@ export async function presignV4(request: {
   if (request.sessionToken) {
     newQuery.set("X-Amz-Security-Token", request.sessionToken);
   }
-  const newQueryString = newQuery.toString().replace("+", "%20"); // Signing requires spaces become %20, never +
+  // Signing requires spaces become %20, never + (and S3 does not form-decode '+' back into a space)
+  const newQueryString = newQuery.toString().replaceAll("+", "%20");
   const signingPath = resource + "?" + newQueryString;
   const encodedPath = resource.split("/").map((part) => encodeURIComponent(part)).join("/");
 


### PR DESCRIPTION
We were using `replace()` instead of `replaceAll()`, resulting in inconsistent treatment of spaces in query string parameters. If a query string parameter contained more than one space, the signature would be incorrect. This fix includes tests that fail without the fix and are now passing.
