### PR TITLE
fix: properly drain ignored body of server responses

### DIFF
--- a/client.test.ts
+++ b/client.test.ts
@@ -334,3 +334,37 @@ Deno.test({
     assert(conditionalUrl.searchParams.get("X-Amz-Signature") !== unconditionalUrl.searchParams.get("X-Amz-Signature"));
   },
 });
+
+Deno.test({
+  name: "makeRequest() releases the response body when returnBody is not set",
+  fn: async () => {
+    const client = new Client({ endPoint: "https://s3.example.com", region: "auto", bucket: "test-bucket" });
+
+    // A multi-chunk response body that tells us how it was disposed of:
+    let cancelled = false;
+    let chunksPulled = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        // Enough chunks that reading only the first one would leave the body unfinished:
+        if (++chunksPulled > 3) return controller.close();
+        controller.enqueue(new TextEncoder().encode("chunk"));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() => Promise.resolve(new Response(body, { status: 200 }))) as typeof globalThis.fetch;
+    let response: Response;
+    try {
+      response = await client.makeRequest({ method: "GET", objectName: "file.txt" });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    // The body must be fully disposed of, not just read one chunk deep and abandoned:
+    assert(cancelled, "response body should have been cancelled");
+    assert(response.bodyUsed, "response body should be marked as used");
+  },
+});

--- a/client.ts
+++ b/client.ts
@@ -318,10 +318,10 @@ export class Client {
     /** The request body */
     payload?: Uint8Array_ | string;
     /**
-     * returnBody: We have to read the request body to avoid leaking resources.
-     * So by default this method will read and ignore the body. If you actually
-     * need it, set returnBody: true and this function won't touch it so that
-     * the caller can read it.
+     * returnBody: We have to consume the response body to avoid leaking resources.
+     * So by default this method will discard the body. If you actually need it,
+     * set returnBody: true and this function won't touch it so that the caller
+     * can read it.
      */
     returnBody?: boolean;
   }): Promise<Response> {
@@ -390,8 +390,8 @@ export class Client {
       );
     }
     if (!options.returnBody) {
-      // Just read the body and ignore its contents, to avoid leaking resources.
-      await response.body?.getReader().read();
+      // Discard the body, to avoid leaking resources.
+      await response.body?.cancel();
     }
     return response;
   }


### PR DESCRIPTION
When the server returned a response for calls like `deleteObject`, `makeBucket`, `removeBucket`, etc, we just ignore the body of the response. This library was doing so using `read()` but that only reads the first chunk, and doesn't mark the stream as closed. In most cases this wasn't a big deal as the body was usually only one chunk. However, it's simpler and more correct to just call `cancel()` which will properly close the stream and which works regardless of the number of chunks in the response.