### PR TITLE
fix: set S3Error.name based on subclass

### DIFF
--- a/errors.test.ts
+++ b/errors.test.ts
@@ -1,0 +1,58 @@
+import { assert } from "@std/assert/assert";
+import { assertEquals } from "@std/assert/equals";
+import * as errors from "./errors.ts";
+
+Deno.test({
+  name: "every error class reports its own class name as .name",
+  fn: () => {
+    // Find every error class this module exports, so that classes added in future are covered too:
+    const errorClasses = Object.entries(errors).filter(
+      ([, value]) => typeof value === "function" && value.prototype instanceof Error,
+    ) as [string, new (arg?: unknown) => Error][];
+    // Sanity check that the filter above actually found them:
+    assert(errorClasses.length >= 9, `expected to find the error classes, found ${errorClasses.length}`);
+
+    for (const [exportName, ErrorClass] of errorClasses) {
+      const instance = new ErrorClass("test");
+      assertEquals(instance.name, ErrorClass.name, `${exportName} should report its class name as .name`);
+      // Which means the class name also shows up when the error is stringified or logged.
+      // (Not every class takes a message as its first argument, so the message may be empty here.)
+      assert(
+        String(instance).startsWith(ErrorClass.name),
+        `${exportName} should be stringified starting with its class name, got "${String(instance)}"`,
+      );
+    }
+  },
+});
+
+Deno.test({
+  name: "error names are useful for diagnostics",
+  fn: async () => {
+    // A subclass with its own constructor:
+    assertEquals(new errors.InvalidBucketNameError("Bad_Bucket").name, "InvalidBucketNameError");
+    assertEquals(
+      String(new errors.InvalidObjectNameError("bad/name")),
+      "InvalidObjectNameError: Invalid object name: bad/name",
+    );
+    // A subclass with no constructor of its own:
+    assertEquals(new errors.InvalidArgumentError("nope").name, "InvalidArgumentError");
+    // The base class itself:
+    assertEquals(new errors.S3Error("generic").name, "S3Error");
+    // And errors parsed from a server response:
+    const parsed = await errors.parseServerError(
+      new Response(`<Error><Code>NoSuchKey</Code><Message>Not found</Message></Error>`, { status: 404 }),
+    );
+    assertEquals(parsed.name, "ServerError");
+    assertEquals(parsed.code, "NoSuchKey"); // The S3 error code is still separate from the class name
+  },
+});
+
+Deno.test({
+  name: "S3Error still accepts the standard Error options argument",
+  fn: () => {
+    const cause = new Error("the underlying problem");
+    const err = new errors.S3Error("wrapper", { cause });
+    assertEquals(err.cause, cause);
+    assertEquals(err.name, "S3Error");
+  },
+});

--- a/errors.ts
+++ b/errors.ts
@@ -9,7 +9,14 @@ import { parse as parseXML } from "./xml-parser.ts";
 /**
  * Base class for all errors raised by this S3 client.
  */
-export class S3Error extends Error {}
+export class S3Error extends Error {
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    // Without this, every subclass would report its name as the unhelpful "Error".
+    // If the names have been mangled during minification, we'll just use `S3Error`.
+    this.name = new.target.name.endsWith("Error") ? new.target.name : "S3Error";
+  }
+}
 
 // Preserve API compatibility with the old name:
 /** @deprecated Use `S3Error` instead. */


### PR DESCRIPTION
This is a minor fix so that when we raise an `S3Error` instance, it reports a useful `name` instead of just `Error`. The keep the library size small, the name is derived from the subclass constructor; in the case of minification that mangles the error names, the name will just be reported as `S3Error`.

In any case, `instanceof` will continue to work correctly just as it always has, and is the only recommended way for checking which type of error was raised.