### PR TITLE
refactor: simplify awsUriEncode implementation

### DIFF
--- a/client.test.ts
+++ b/client.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
+import { assertRejects } from "@std/assert/rejects";
 import { assertStringIncludes } from "@std/assert/string-includes";
 import { assertThrows } from "@std/assert/throws";
 import { Client } from "./client.ts";
@@ -332,6 +333,35 @@ Deno.test({
     assertEquals(unconditionalUrl.searchParams.get("X-Amz-SignedHeaders"), "host");
     // And it must change the signature:
     assert(conditionalUrl.searchParams.get("X-Amz-Signature") !== unconditionalUrl.searchParams.get("X-Amz-Signature"));
+  },
+});
+
+Deno.test({
+  name: "object keys that cannot be represented in UTF-8 are rejected before signing",
+  fn: async () => {
+    const client = new Client({
+      endPoint: "https://s3.example.com",
+      region: "us-east-1",
+      bucket: "test-bucket",
+      accessKey: "test-access-key",
+      secretKey: "test-secret-key",
+    });
+    const loneSurrogate = "dir/lone\ud800surrogate.txt";
+
+    // Every method that takes an object key should report a normal S3Error, rather than letting a
+    // raw URIError escape from the URL encoding:
+    await assertRejects(() => client.getObject(loneSurrogate), S3Errors.InvalidObjectNameError);
+    await assertRejects(() => client.statObject(loneSurrogate), S3Errors.InvalidObjectNameError);
+    await assertRejects(() => client.deleteObject(loneSurrogate), S3Errors.InvalidObjectNameError);
+    await assertRejects(() => client.putObject(loneSurrogate, "data"), S3Errors.InvalidObjectNameError);
+    await assertRejects(
+      () => client.copyObject({ sourceKey: "source.txt" }, loneSurrogate),
+      S3Errors.InvalidObjectNameError,
+    );
+    // These three return a Promise but validate synchronously, so they throw rather than reject:
+    assertThrows(() => client.getPresignedUrl("GET", loneSurrogate), S3Errors.InvalidObjectNameError);
+    assertThrows(() => client.presignedGetObject(loneSurrogate), S3Errors.InvalidObjectNameError);
+    assertThrows(() => client.presignedPostObject(loneSurrogate), S3Errors.InvalidObjectNameError);
   },
 });
 

--- a/helpers.test.ts
+++ b/helpers.test.ts
@@ -1,5 +1,14 @@
 import { assertEquals } from "@std/assert/equals";
-import { bin2hex, isValidBucketName, isValidPort, makeDateLong, makeDateShort, sha256digestHex } from "./helpers.ts";
+import {
+  bin2hex,
+  isValidBucketName,
+  isValidObjectName,
+  isValidPort,
+  isValidPrefix,
+  makeDateLong,
+  makeDateShort,
+  sha256digestHex,
+} from "./helpers.ts";
 
 Deno.test({
   name: "isValidPort",
@@ -55,6 +64,41 @@ Deno.test({
         fn: () => assertEquals(isValidBucketName(validName), true),
       });
     }
+  },
+});
+
+Deno.test({
+  name: "isValidObjectName",
+  fn: () => {
+    // ✅ Valid:
+    assertEquals(isValidObjectName("file.txt"), true);
+    assertEquals(isValidObjectName("dir/sub dir/file (final)+v2.txt"), true);
+    assertEquals(isValidObjectName("x".repeat(1024)), true);
+    assertEquals(isValidObjectName("файл"), true);
+    assertEquals(isValidObjectName("emoji-😀.txt"), true);
+    // ❌ Invalid:
+    assertEquals(isValidObjectName(""), false); // empty
+    assertEquals(isValidObjectName("x".repeat(1025)), false); // too long
+    // @ts-expect-error isValidObjectName normally accepts a string
+    assertEquals(isValidObjectName(undefined), false);
+    // A lone surrogate cannot be represented in UTF-8, so such a key can never reach the server as
+    // written. It must be rejected here rather than silently mangled into U+FFFD:
+    assertEquals(isValidObjectName("\ud800"), false); // lone high surrogate
+    assertEquals(isValidObjectName("\udfff"), false); // lone low surrogate
+    assertEquals(isValidObjectName("dir/lone\ud800surrogate.txt"), false);
+  },
+});
+
+Deno.test({
+  name: "isValidPrefix",
+  fn: () => {
+    // ✅ Valid:
+    assertEquals(isValidPrefix(""), true); // unlike an object name, a prefix may be empty
+    assertEquals(isValidPrefix("dir/"), true);
+    assertEquals(isValidPrefix("emoji-😀"), true);
+    // ❌ Invalid:
+    assertEquals(isValidPrefix("x".repeat(1025)), false); // too long
+    assertEquals(isValidPrefix("dir/\ud800"), false); // lone surrogate
   },
 });
 

--- a/helpers.ts
+++ b/helpers.ts
@@ -59,6 +59,10 @@ export function isValidObjectName(objectName: string) {
 export function isValidPrefix(prefix: string) {
   if (typeof prefix !== "string") return false;
   if (prefix.length > 1024) return false;
+  // A lone surrogate cannot be represented in UTF-8, so such a key could never reach the server as
+  // written. Reject it here, rather than letting it be silently mangled into U+FFFD or throw a
+  // URIError from deep inside the URL encoding.
+  if (!prefix.isWellFormed()) return false;
   return true;
 }
 

--- a/signing.test.ts
+++ b/signing.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert/equals";
 import { assertStringIncludes } from "@std/assert/string-includes";
+import { assertThrows } from "@std/assert/throws";
 import { bin2hex } from "./helpers.ts";
 import { _internalMethods as methods, presignPostV4, presignV4, signV4 } from "./signing.ts";
 
@@ -403,5 +404,21 @@ Deno.test({
     assertEquals(awsUriEncode("a.b-c_d~e"), "a.b-c_d~e");
     assertEquals(awsUriEncode("words with spaces"), "words%20with%20spaces");
     assertEquals(awsUriEncode("файл"), "%D1%84%D0%B0%D0%B9%D0%BB");
+    // Only these are unreserved; every other ASCII character must be percent-encoded, in uppercase hex:
+    assertEquals(awsUriEncode("-._~"), "-._~");
+    // ...which notably includes the five that encodeURIComponent() leaves alone:
+    assertEquals(awsUriEncode("!'()*"), "%21%27%28%29%2A");
+    assertEquals(awsUriEncode("a+b&c=d?e#f"), "a%2Bb%26c%3Dd%3Fe%23f");
+    assertEquals(awsUriEncode("%"), "%25");
+    assertEquals(awsUriEncode(""), "");
+    // Slashes are encoded unless they are part of an object key:
+    assertEquals(awsUriEncode("/a//b/", true), "/a//b/");
+    assertEquals(awsUriEncode("/a//b/", false), "%2Fa%2F%2Fb%2F");
+    // Multi-byte characters are encoded per UTF-8 byte, including outside the BMP:
+    assertEquals(awsUriEncode("ሴ"), "%E1%88%B4");
+    assertEquals(awsUriEncode("😀"), "%F0%9F%98%80");
+    // A lone surrogate cannot be represented in UTF-8. Object names should be validated by
+    // isValidObjectName() long before they reach the signer, so this is an internal/usage error:
+    assertThrows(() => awsUriEncode("\ud800"), URIError);
   },
 });

--- a/signing.ts
+++ b/signing.ts
@@ -175,17 +175,6 @@ function getHeadersToSign(headers: Headers): string[] {
   return headersToSign;
 }
 
-const CODES = {
-  A: "A".charCodeAt(0),
-  Z: "Z".charCodeAt(0),
-  a: "a".charCodeAt(0),
-  z: "z".charCodeAt(0),
-  "0": "0".charCodeAt(0),
-  "9": "9".charCodeAt(0),
-  "/": "/".charCodeAt(0),
-};
-const ALLOWED_BYTES = "-._~".split("").map((s) => s.charCodeAt(0));
-
 /**
  * Canonical URI encoding for signing, per AWS documentation:
  * 1. URI encode every byte except the unreserved characters:
@@ -200,25 +189,16 @@ const ALLOWED_BYTES = "-._~".split("").map((s) => s.charCodeAt(0));
  *
  * See https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
  *
- * @param string the string to encode.
+ * @param string the string to encode. Must be well-formed Unicode; object names are validated by
+ *   isValidObjectName() before they reach here, so a lone surrogate is a caller error and will
+ *   throw a URIError.
  */
 function awsUriEncode(string: string, allowSlashes = false) {
-  const bytes: Uint8Array = new TextEncoder().encode(string);
-  let encoded = "";
-  for (const byte of bytes) {
-    if (
-      (byte >= CODES.A && byte <= CODES.Z) ||
-      (byte >= CODES.a && byte <= CODES.z) ||
-      (byte >= CODES["0"] && byte <= CODES["9"]) ||
-      (ALLOWED_BYTES.includes(byte)) ||
-      (byte == CODES["/"] && allowSlashes)
-    ) {
-      encoded += String.fromCharCode(byte);
-    } else {
-      encoded += "%" + byte.toString(16).padStart(2, "0").toUpperCase();
-    }
-  }
-  return encoded;
+  // encodeURIComponent() already does all of the above, using uppercase hex and encoding spaces as
+  // %20, except that it leaves these five characters unencoded, which AWS considers reserved.
+  const encoded = encodeURIComponent(string)
+    .replace(/[!'()*]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase());
+  return allowSlashes ? encoded.replaceAll("%2F", "/") : encoded;
 }
 
 /**


### PR DESCRIPTION
This PR simplifies our implementation of `awsUriEncode`, slightly decreasing the bundle size of the library. All of the existing tests pass unchanged, and the test suite has been expanded to be even more rigorous.