### PR TITLE
fix!: consistently reject with errors; don't throw synchronously

### DIFF
--- a/client.test.ts
+++ b/client.test.ts
@@ -358,10 +358,9 @@ Deno.test({
       () => client.copyObject({ sourceKey: "source.txt" }, loneSurrogate),
       S3Errors.InvalidObjectNameError,
     );
-    // These three return a Promise but validate synchronously, so they throw rather than reject:
-    assertThrows(() => client.getPresignedUrl("GET", loneSurrogate), S3Errors.InvalidObjectNameError);
-    assertThrows(() => client.presignedGetObject(loneSurrogate), S3Errors.InvalidObjectNameError);
-    assertThrows(() => client.presignedPostObject(loneSurrogate), S3Errors.InvalidObjectNameError);
+    assertRejects(() => client.getPresignedUrl("GET", loneSurrogate), S3Errors.InvalidObjectNameError);
+    assertRejects(() => client.presignedGetObject(loneSurrogate), S3Errors.InvalidObjectNameError);
+    assertRejects(() => client.presignedPostObject(loneSurrogate), S3Errors.InvalidObjectNameError);
   },
 });
 

--- a/client.ts
+++ b/client.ts
@@ -524,7 +524,7 @@ export class Client {
    * @param objectName The object name, e.g. "path/to/file.txt"
    * @param options Detailed options, such as expiry time for the pre-signed URL. Use expirySeconds to specify the expiry time; default is seven days.
    */
-  getPresignedUrl(
+  async getPresignedUrl(
     method: "GET" | "PUT" | "HEAD" | "DELETE",
     objectName: string,
     options: {
@@ -555,7 +555,7 @@ export class Client {
     const requestDate = options.requestDate ?? new Date();
     const expirySeconds = options.expirySeconds ?? 24 * 60 * 60 * 7; // default expiration is 7 days in seconds.
 
-    return presignV4({
+    return await presignV4({
       protocol: this.protocol,
       headers,
       method,
@@ -1030,7 +1030,7 @@ export class Client {
    * @param options - Additional options
    * @returns An object with url and fields that can be used to construct a form for direct uploads
    */
-  presignedPostObject(
+  async presignedPostObject(
     objectName: string,
     options: {
       /**
@@ -1071,7 +1071,7 @@ export class Client {
     const requestDate = options.requestDate || new Date();
     const expirySeconds = options.expirySeconds ?? 3600; // Default 1 hour
 
-    return presignPostV4({
+    return await presignPostV4({
       protocol: this.protocol,
       host: this.host,
       bucket: bucketName,


### PR DESCRIPTION
`getPresignedUrl`, `presignedGetObject`, and `presignedPostObject` are all marked as returning a `Promise`, but if you gave them invalid input that caused e.g. an `InvalidObjectNameError`, they would `throw` the exception synchronously rather than returning a rejected `Promise`. This was inconsistent with the other API functions and with how you'd expect async functions to work in general, so I've made them reject, consistent with the others.

This is _technically_ a breaking change, although it should have very limited impact.