### PR TITLE
refactor: simplify the XML parser, add childText helper

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -11,7 +11,7 @@ import {
 } from "./helpers.ts";
 import { ObjectUploader } from "./object-uploader.ts";
 import { presignPostV4, presignV4, signV4 } from "./signing.ts";
-import { parse as parseXML } from "./xml-parser.ts";
+import { childText, parse as parseXML } from "./xml-parser.ts";
 
 export interface ClientOptions {
   /**
@@ -690,8 +690,8 @@ export class Client {
       const responseText = await pageResponse.text();
       // Parse the response XML.
       // See https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#API_ListObjectsV2_ResponseSyntax
-      const root = parseXML(responseText).root;
-      if (!root || root.name !== "ListBucketResult") {
+      const root = parseXML(responseText);
+      if (root?.name !== "ListBucketResult") {
         throw new Error(`Unexpected response: ${responseText}`);
       }
       // If a delimiter was specified, first return any common prefixes from this page of results:
@@ -710,10 +710,10 @@ export class Client {
       for (const objectElement of root.children.filter((c) => c.name === "Contents")) {
         toYield.push({
           type: "Object",
-          key: objectElement.children.find((c) => c.name === "Key")?.content ?? "",
-          etag: sanitizeETag(objectElement.children.find((c) => c.name === "ETag")?.content ?? ""),
-          size: parseInt(objectElement.children.find((c) => c.name === "Size")?.content ?? "", 10),
-          lastModified: new Date(objectElement.children.find((c) => c.name === "LastModified")?.content ?? "invalid"),
+          key: childText(objectElement, "Key") ?? "",
+          etag: sanitizeETag(childText(objectElement, "ETag") ?? ""),
+          size: parseInt(childText(objectElement, "Size") ?? "", 10),
+          lastModified: new Date(childText(objectElement, "LastModified") ?? "invalid"),
         });
         resultCount++;
       }
@@ -728,10 +728,10 @@ export class Client {
       for (const entry of toYield) {
         yield entry;
       }
-      const isTruncated = root.children.find((c) => c.name === "IsTruncated")?.content === "true";
+      const isTruncated = childText(root, "IsTruncated") === "true";
       if (isTruncated) {
         // There are more results.
-        const nextContinuationToken = root.children.find((c) => c.name === "NextContinuationToken")?.content;
+        const nextContinuationToken = childText(root, "NextContinuationToken");
         if (!nextContinuationToken) {
           throw new Error("Unexpectedly missing continuation token, but server said there are more results.");
         }
@@ -969,12 +969,12 @@ export class Client {
     const responseText = await response.text();
     // Parse the response XML.
     // See https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_ResponseSyntax
-    const root = parseXML(responseText).root;
-    if (!root || root.name !== "CopyObjectResult") {
+    const root = parseXML(responseText);
+    if (root?.name !== "CopyObjectResult") {
       throw new Error(`Unexpected response: ${responseText}`);
     }
-    const etagString = root.children.find((c) => c.name === "ETag")?.content ?? "";
-    const lastModifiedString = root.children.find((c) => c.name === "LastModified")?.content;
+    const etagString = childText(root, "ETag") ?? "";
+    const lastModifiedString = childText(root, "LastModified");
     if (lastModifiedString === undefined) {
       throw new Error("Unable to find <LastModified>...</LastModified> from the server.");
     }

--- a/errors.ts
+++ b/errors.ts
@@ -4,7 +4,7 @@
  * Every error is a subclass of S3Error.
  */
 
-import { parse as parseXML } from "./xml-parser.ts";
+import { childText, parse as parseXML } from "./xml-parser.ts";
 
 /**
  * Base class for all errors raised by this S3 client.
@@ -100,19 +100,21 @@ export class ServerError extends S3Error {
 /** Helper function to parse an error returned by the S3 server. */
 export async function parseServerError(response: Response): Promise<ServerError> {
   try {
-    const xmlParsed = parseXML(await response.text());
-    const errorRoot = xmlParsed.root;
+    const errorRoot = parseXML(await response.text());
     if (errorRoot?.name !== "Error") {
       throw new Error("Invalid root, expected <Error>");
     }
-    const code = errorRoot.children.find((c) => c.name === "Code")?.content ?? "UnknownErrorCode";
-    const message = errorRoot.children.find((c) => c.name === "Message")?.content ??
-      "The error message could not be determined.";
-    const key = errorRoot.children.find((c) => c.name === "Key")?.content;
-    const bucketName = errorRoot.children.find((c) => c.name === "BucketName")?.content;
-    const resource = errorRoot.children.find((c) => c.name === "Resource")?.content; // e.g. the object key
-    const region = errorRoot.children.find((c) => c.name === "Region")?.content;
-    return new ServerError(response.status, code, message, { key, bucketName, resource, region });
+    return new ServerError(
+      response.status,
+      childText(errorRoot, "Code") ?? "UnknownErrorCode",
+      childText(errorRoot, "Message") ?? "The error message could not be determined.",
+      {
+        key: childText(errorRoot, "Key"),
+        bucketName: childText(errorRoot, "BucketName"),
+        resource: childText(errorRoot, "Resource"), // e.g. the object key
+        region: childText(errorRoot, "Region"),
+      },
+    );
   } catch {
     return new ServerError(
       response.status,

--- a/object-uploader.ts
+++ b/object-uploader.ts
@@ -1,6 +1,6 @@
 import type { Client, ObjectMetadata, UploadedObjectInfo } from "./client.ts";
 import { getVersionId, sanitizeETag, type Uint8Array_ } from "./helpers.ts";
-import { parse as parseXML } from "./xml-parser.ts";
+import { childText, parse as parseXML } from "./xml-parser.ts";
 
 // Metadata headers that must be included in each part of a multi-part upload
 const multipartTagAlongMetadataKeys = [
@@ -174,11 +174,11 @@ async function initiateNewMultipartUpload(
   //   <UploadId>422f976b-35e0-4a55-aca7-bf2d46277f93</UploadId>
   // </InitiateMultipartUploadResult>
   const responseText = await response.text();
-  const root = parseXML(responseText).root;
-  if (!root || root.name !== "InitiateMultipartUploadResult") {
+  const root = parseXML(responseText);
+  if (root?.name !== "InitiateMultipartUploadResult") {
     throw new Error(`Unexpected response: ${responseText}`);
   }
-  const uploadId = root.children.find((c) => c.name === "UploadId")?.content;
+  const uploadId = childText(root, "UploadId");
   if (!uploadId) {
     throw new Error(`Unable to get UploadId from response: ${responseText}`);
   }
@@ -216,11 +216,11 @@ async function completeMultipartUpload(
   //   <Key>test-32m.dat</Key>
   //   <ETag>&#34;4581589392ae60eafdb031f441858c7a-7&#34;</ETag>
   // </CompleteMultipartUploadResult>
-  const root = parseXML(responseText).root;
-  if (!root || root.name !== "CompleteMultipartUploadResult") {
+  const root = parseXML(responseText);
+  if (root?.name !== "CompleteMultipartUploadResult") {
     throw new Error(`Unexpected response: ${responseText}`);
   }
-  const etagRaw = root.children.find((c) => c.name === "ETag")?.content;
+  const etagRaw = childText(root, "ETag");
   if (!etagRaw) throw new Error(`Unable to get ETag from response: ${responseText}`);
   const versionId = getVersionId(response.headers);
   return {

--- a/xml-parser.test.ts
+++ b/xml-parser.test.ts
@@ -1,0 +1,94 @@
+import { assertEquals } from "@std/assert/equals";
+import { childText, parse } from "./xml-parser.ts";
+
+const declaration = `<?xml version="1.0" encoding="UTF-8"?>`;
+
+Deno.test({
+  name: "parse - skips the XML declaration",
+  fn: async (t) => {
+    // Every response from S3 begins with a declaration, which we ignore entirely:
+    for (
+      const prefix of [
+        "",
+        declaration,
+        `<?xml version="1.0"?>`,
+        `<?xml version='1.0' encoding='utf-8'?>`,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`,
+        `${declaration}\n  `,
+        `<!-- a comment -->`,
+        `${declaration}<!-- a comment -->`,
+      ]
+    ) {
+      await t.step({
+        name: `prefixed with ${JSON.stringify(prefix) || "nothing"}`,
+        fn: () => {
+          const root = parse(`${prefix}<Root><Child>value</Child></Root>`);
+          assertEquals(root?.name, "Root");
+          assertEquals(childText(root!, "Child"), "value");
+        },
+      });
+    }
+  },
+});
+
+Deno.test({
+  name: "parse - returns undefined when there is no root element",
+  fn: () => {
+    assertEquals(parse(""), undefined);
+    assertEquals(parse("   "), undefined);
+    assertEquals(parse("not xml at all"), undefined);
+    assertEquals(parse(declaration), undefined);
+  },
+});
+
+Deno.test({
+  name: "parse - elements, attributes, and entities",
+  fn: () => {
+    const root = parse(
+      `${declaration}<Root attr="v" other='w'><Empty/><Text>hello</Text><Esc>&lt;a&gt; &amp; b</Esc></Root>`,
+    );
+    assertEquals(root?.name, "Root");
+    assertEquals(root?.attributes, { attr: "v", other: "w" });
+    assertEquals(root?.children.map((c) => c.name), ["Empty", "Text", "Esc"]);
+    assertEquals(childText(root!, "Text"), "hello");
+    // Basic entities are decoded:
+    assertEquals(childText(root!, "Esc"), "<a> & b");
+    // Namespaced tag names are kept as-is:
+    assertEquals(parse(`<ns:Root xmlns:ns="urn:x"><ns:Child>v</ns:Child></ns:Root>`)?.name, "ns:Root");
+  },
+});
+
+Deno.test({
+  name: "childText",
+  fn: () => {
+    // A realistic ListObjectsV2 response:
+    const root = parse(`${declaration}
+      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Name>test-bucket</Name>
+        <IsTruncated>true</IsTruncated>
+        <NextContinuationToken>token-abc</NextContinuationToken>
+        <Contents>
+          <Key>dir/file.txt</Key>
+          <LastModified>2024-01-01T00:00:00.000Z</LastModified>
+          <ETag>&#34;d41d8cd9&#34;</ETag>
+          <Size>1234</Size>
+        </Contents>
+      </ListBucketResult>`)!;
+
+    assertEquals(root.name, "ListBucketResult");
+    assertEquals(childText(root, "IsTruncated"), "true");
+    assertEquals(childText(root, "NextContinuationToken"), "token-abc");
+    // Missing children are undefined, not an error:
+    assertEquals(childText(root, "NoSuchElement"), undefined);
+    // It only looks at direct children, not deeper descendants:
+    assertEquals(childText(root, "Key"), undefined);
+
+    const contents = root.children.find((c) => c.name === "Contents")!;
+    assertEquals(childText(contents, "Key"), "dir/file.txt");
+    assertEquals(childText(contents, "Size"), "1234");
+
+    // Where an element is repeated, the first one wins:
+    const dup = parse(`<Root><Dup>1</Dup><Dup>2</Dup></Root>`)!;
+    assertEquals(childText(dup, "Dup"), "1");
+  },
+});

--- a/xml-parser.ts
+++ b/xml-parser.ts
@@ -6,14 +6,7 @@
  * "Simple non-compliant XML parser because we just need to parse some basic responses"
  */
 
-interface Document {
-  declaration: {
-    attributes: Record<string, string>;
-  };
-  root: Xml | undefined;
-}
-
-interface Xml {
+export interface Xml {
   name: string;
   attributes: Record<string, string>;
   content?: string;
@@ -21,50 +14,25 @@ interface Xml {
 }
 
 /**
- * Parse the given string of `xml`.
+ * Get the text content of the first child element with the given name, if there is one.
  */
-export function parse(xml: string): Document {
+export function childText(node: Xml, name: string): string | undefined {
+  return node.children.find((c) => c.name === name)?.content;
+}
+
+/**
+ * Parse the given string of `xml` and return its root element, if it has one.
+ */
+export function parse(xml: string): Xml | undefined {
   xml = xml.trim();
 
   // strip comments
   xml = xml.replace(/<!--[\s\S]*?-->/g, "");
 
-  return document();
+  // skip the declaration, e.g. <?xml version="1.0" encoding="UTF-8"?> - we never look at it
+  match(/^<\?xml[\s\S]*?\?>\s*/);
 
-  /**
-   * XML document.
-   */
-  function document(): Document {
-    return {
-      declaration: declaration(),
-      root: tag(),
-    };
-  }
-
-  /**
-   * Declaration.
-   */
-  function declaration() {
-    const m = match(/^<\?xml\s*/);
-    if (!m) return;
-
-    // tag.
-    // deno-lint-ignore no-explicit-any
-    const node: any = {
-      attributes: {},
-    };
-
-    // attributes
-    while (!(eos() || is("?>"))) {
-      const attr = attribute();
-      if (!attr) return node;
-      node.attributes[attr.name] = attr.value;
-    }
-
-    match(/\?>\s*/);
-
-    return node;
-  }
+  return tag();
 
   /**
    * Tag.


### PR DESCRIPTION
This optimization PR streamlines our built-in XML parser in two ways:
* Removes the `<?xml` declaration parsing (we can just ignore it)
* Adds a `childText` helper for the common pattern of `element.children.find((c) => c.name === "Key")?.content`

This reduces the minified code size by ~3.3%, although the impact on the gzipped code size is minimal since the code that `childText` replaced was highly repetitive. 