### PR TITLE
Optimize uploading logic, reduce memory usage, fix unbounded parallelism in uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ supports the `fetch` API, web streams API, and ES modules (ESM).
   - Like `getObject`, this also supports streaming the response if you want to.
 - Upload an object: `client.putObject("key", streamOrData, options)`
   - Can upload from a `string`, `Uint8Array`, or `ReadableStream`
-  - Can split large uploads into multiple parts and uploads parts in parallel.
+  - Can split large uploads into multiple parts, and uploads a limited number of parts in parallel.
+  - Uploads of 64MB or more are split into 64MB parts by default. Since S3 allows at most 10,000 parts, that supports
+    objects up to 640GB; to upload something bigger, or to stream something bigger without passing `size`, pass a larger
+    `partSize` (up to 5GB).
   - Can set custom headers, ACLs, and other metadata on the new object (example below).
 - Copy an object: `client.copyObject({ sourceKey: "source", options }, "dest", options)`
   - Can copy between different buckets.

--- a/client.ts
+++ b/client.ts
@@ -10,7 +10,7 @@ import {
   sha256digestHex,
   type Uint8Array_,
 } from "./helpers.ts";
-import { ObjectUploader } from "./object-uploader.ts";
+import { ObjectUploader, uploadSingleRequest } from "./object-uploader.ts";
 import { presignPostV4, presignV4, signV4 } from "./signing.ts";
 import { childText, parse as parseXML } from "./xml-parser.ts";
 
@@ -158,6 +158,11 @@ const minimumPartSize = 5 * 1024 * 1024;
 const maximumPartSize = 5 * 1024 * 1024 * 1024;
 /** The maximum allowed object size for multi-part uploads. https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html */
 const maxObjectSize = 5 * 1024 * 1024 * 1024 * 1024;
+/**
+ * The part size we use for multi-part uploads unless the object is so big that it would need more
+ * than the 10,000 parts that S3 allows. With 10,000 parts, this supports objects up to 640GB.
+ */
+const defaultPartSize = 64 * 1024 * 1024;
 
 /**
  * Interface for presigned POST policy conditions
@@ -754,26 +759,25 @@ export class Client {
       size?: number;
       bucketName?: string;
       /**
-       * For large uploads, split them into parts of this size.
-       * Default: 64MB if object size is known, 500MB if total object size is unknown.
-       * This is a minimum; larger part sizes may be required for large uploads or if the total size is unknown.
+       * For large uploads, split them into parts of this size. Default: 64MB.
+       * This is also roughly how much data we buffer in memory per part that is being uploaded.
+       * Since S3 allows at most 10,000 parts, the default supports objects up to 640GB; to upload
+       * something larger, or to stream something larger without specifying `size`, set a bigger
+       * part size (up to 5GB).
        */
       partSize?: number;
     },
   ): Promise<UploadedObjectInfo> {
     const bucketName = this.checkNames(objectName, options);
 
-    // Prepare a readable stream for the upload:
+    // Prepare the data for the upload:
     let size: number | undefined;
-    let stream: ReadableStream<Uint8Array>;
-    if (streamOrData instanceof ReadableStream) {
-      stream = streamOrData;
-    } else {
+    let bytes: Uint8Array_ | undefined;
+    if (!(streamOrData instanceof ReadableStream)) {
       // If we've been given a string, convert to binary using UTF-8.
-      const bytes: Uint8Array_ = typeof streamOrData === "string" ? encoder.encode(streamOrData) : streamOrData;
+      bytes = typeof streamOrData === "string" ? encoder.encode(streamOrData) : streamOrData;
       if (!(bytes instanceof Uint8Array)) throw new errors.InvalidArgumentError(`Invalid stream/data type provided.`);
       size = bytes.byteLength;
-      stream = new Blob([bytes]).stream();
     }
 
     // Validate the size parameter
@@ -800,7 +804,17 @@ export class Client {
       throw new errors.InvalidArgumentError(`Part size should be less than 5GB`);
     }
 
-    // s3 requires that all non-end chunks be at least `this.partSize`,
+    const metadata = options?.metadata ?? {};
+
+    if (bytes !== undefined && bytes.byteLength < partSize) {
+      // We already have all of the data in memory and it fits into a single request, so upload it
+      // directly. This avoids converting it to a stream and copying it through the chunker.
+      return uploadSingleRequest({ client: this, bucketName, objectName, metadata, payload: bytes });
+    }
+
+    // Prepare for streaming upload.
+    const stream = bytes === undefined ? streamOrData as ReadableStream<Uint8Array> : new Blob([bytes]).stream();
+    // s3 requires that all non-end chunks be at least `partSize`,
     // so we chunk the stream until we hit either that size or the end before
     // we flush it to s3.
     const chunker = new TransformChunkSizes(partSize);
@@ -812,7 +826,7 @@ export class Client {
       bucketName,
       objectName,
       partSize,
-      metadata: options?.metadata ?? {},
+      metadata,
     });
     // stream => chunker => uploader
     await stream.pipeThrough(chunker).pipeTo(uploader);
@@ -831,15 +845,16 @@ export class Client {
    */
   protected calculatePartSize(size: number | undefined): number {
     if (size === undefined) {
-      // If we don't know the total size (e.g. we're streaming data), assume it's
-      // the largest allowed object size, so we can guarantee the upload works
-      // regardless of the total size.
-      size = maxObjectSize;
+      // If we don't know the total size (e.g. we're streaming data), use the default part size.
+      // We don't assume the largest allowed object size (5TB), because the part size is also how
+      // much data we have to buffer in memory before we can start uploading each part. This
+      // supports streams of up to 640GB; bigger ones need an explicit "size" or "partSize".
+      return defaultPartSize;
     }
     if (size > maxObjectSize) {
       throw new TypeError(`size should not be more than ${maxObjectSize}`);
     }
-    let partSize = 64 * 1024 * 1024; // Start with 64MB
+    let partSize = defaultPartSize; // Start with 64MB
     while (true) {
       // If partSize is big enough to accomodate the object size, then use it.
       if ((partSize * 10_000) > size) {

--- a/integration.ts
+++ b/integration.ts
@@ -73,6 +73,28 @@ Deno.test({
 });
 
 Deno.test({
+  name: "putObject() can upload an empty file",
+  fn: async () => {
+    // The etag of an empty object is the MD5 of no bytes at all:
+    const emptyEtag = "d41d8cd98f00b204e9800998ecf8427e";
+
+    const fromString = await client.putObject("test-empty-string.txt", "");
+    assertEquals(fromString.etag, emptyEtag);
+    assertEquals((await client.statObject("test-empty-string.txt")).size, 0);
+    assertEquals(await (await client.getObject("test-empty-string.txt")).text(), "");
+
+    const fromBytes = await client.putObject("test-empty-bytes.dat", new Uint8Array(0));
+    assertEquals(fromBytes.etag, emptyEtag);
+    assertEquals((await client.statObject("test-empty-bytes.dat")).size, 0);
+
+    // Uploading an empty stream works too:
+    const fromStream = await client.putObject("test-empty-stream.dat", new Blob([]).stream());
+    assertEquals(fromStream.etag, emptyEtag);
+    assertEquals((await client.statObject("test-empty-stream.dat")).size, 0);
+  },
+});
+
+Deno.test({
   name: "putObject() can set metadata",
   fn: async () => {
     const key = "test-with-metadata.txt";

--- a/object-uploader.test.ts
+++ b/object-uploader.test.ts
@@ -1,0 +1,90 @@
+import { assert } from "@std/assert/assert";
+import { assertEquals } from "@std/assert/equals";
+import type { Client } from "./client.ts";
+import { ObjectUploader } from "./object-uploader.ts";
+
+/**
+ * A fake Client that pretends to be an S3 server, so we can test the multi-part upload logic
+ * without a real server. It records how many part uploads were in flight at the same time.
+ */
+function makeFakeClient(partUploadDelayMs = 5) {
+  const state = { inFlight: 0, maxInFlight: 0, partsUploaded: [] as number[] };
+  const client = {
+    // deno-lint-ignore no-explicit-any
+    async makeRequest(options: any): Promise<Response> {
+      if (options.query === undefined) {
+        // A plain PUT: the whole object is being uploaded in a single request.
+        return new Response(null, { headers: { etag: `"single-request-etag"` } });
+      } else if (options.query === "uploads") {
+        return new Response(
+          `<InitiateMultipartUploadResult><UploadId>fake-upload-id</UploadId></InitiateMultipartUploadResult>`,
+        );
+      } else if (typeof options.query === "string" && options.query.startsWith("uploadId=")) {
+        return new Response(
+          `<CompleteMultipartUploadResult><ETag>&#34;fake-etag-20&#34;</ETag></CompleteMultipartUploadResult>`,
+        );
+      }
+      // Otherwise, this is uploading one part of the multi-part upload:
+      const partNumber = Number(options.query.partNumber);
+      state.inFlight++;
+      state.maxInFlight = Math.max(state.maxInFlight, state.inFlight);
+      await new Promise((resolve) => setTimeout(resolve, partUploadDelayMs));
+      state.inFlight--;
+      state.partsUploaded.push(partNumber);
+      return new Response(null, { headers: { etag: `"fake-etag-${partNumber}"` } });
+    },
+  };
+  return { client: client as unknown as Client, state };
+}
+
+Deno.test({
+  name: "ObjectUploader uploads parts in parallel, but only a limited number at a time",
+  fn: async () => {
+    const { client, state } = makeFakeClient();
+    const partSize = 10;
+    const uploader = new ObjectUploader({
+      client,
+      bucketName: "test-bucket",
+      objectName: "test-key",
+      partSize,
+      metadata: {},
+    });
+
+    // Write 20 parts. Each chunk is exactly partSize, so none of them is the "small enough for a
+    // single request" case, and we get a 20-part multi-part upload.
+    const writer = uploader.getWriter();
+    for (let i = 0; i < 20; i++) {
+      await writer.write(new Uint8Array(partSize).fill(i));
+    }
+    await writer.close();
+
+    assertEquals(state.partsUploaded.length, 20);
+    assertEquals(uploader.getResult().etag, "fake-etag-20");
+    // Parts are uploaded in parallel...
+    assert(state.maxInFlight > 1, `expected parallel uploads, but only ${state.maxInFlight} was in flight at a time`);
+    // ...but we never have more than a few in flight at once, since each one costs us partSize
+    // bytes of memory until the server accepts it.
+    assert(state.maxInFlight <= 4, `expected at most 4 parts in flight, but ${state.maxInFlight} were`);
+  },
+});
+
+Deno.test({
+  name: "ObjectUploader uses a single request when the data is smaller than the part size",
+  fn: async () => {
+    const { client, state } = makeFakeClient();
+    const uploader = new ObjectUploader({
+      client,
+      bucketName: "test-bucket",
+      objectName: "test-key",
+      partSize: 1024,
+      metadata: {},
+    });
+    const writer = uploader.getWriter();
+    await writer.write(new Uint8Array(1000));
+    await writer.close();
+
+    // It never started a multi-part upload; the ETag comes from the single PUT request:
+    assertEquals(state.partsUploaded, []);
+    assertEquals(uploader.getResult().etag, "single-request-etag");
+  },
+});

--- a/object-uploader.ts
+++ b/object-uploader.ts
@@ -10,6 +10,43 @@ const multipartTagAlongMetadataKeys = [
 ];
 
 /**
+ * How many parts of a multi-part upload we will upload in parallel. Each part in flight is held in
+ * memory until the server has accepted it, so this puts an upper bound on how much memory an upload
+ * can use (roughly this many times the part size).
+ */
+const maxConcurrentParts = 4;
+
+/** The maximum number of parts in a multi-part upload. https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html */
+const maxParts = 10_000;
+
+/**
+ * Upload an object using a single PUT request, and return the resulting object info.
+ *
+ * This can only be used for objects up to 5GB, and is what we use whenever the data is small enough
+ * that we don't need a multi-part upload.
+ */
+export async function uploadSingleRequest(
+  { client, metadata, ...requestArgs }: {
+    client: Client;
+    bucketName: string;
+    objectName: string;
+    metadata: Record<string, string>;
+    payload: Uint8Array_ | string;
+  },
+): Promise<UploadedObjectInfo> {
+  const response = await client.makeRequest({
+    method: "PUT",
+    // Set user metadata as this is not a multipart upload. (makeRequest sets Content-Length for us.)
+    headers: new Headers(metadata),
+    ...requestArgs,
+  });
+  return {
+    etag: sanitizeETag(response.headers.get("etag") ?? undefined),
+    versionId: getVersionId(response.headers),
+  };
+}
+
+/**
  * Stream a file to S3
  *
  * We assume that TransformChunkSizes has been used first, so that this stream
@@ -37,8 +74,12 @@ export class ObjectUploader extends WritableStream<Uint8Array_> {
     const etags: { part: number; etag: string }[] = [];
     /** If an error occurs during multi-part uploads, we temporarily store it here. */
     let multiUploadError: Error | undefined;
-    /** If doing multi-part upload, this holds a promise for each part so we can upload them in parallel */
-    const partsPromises: Promise<Response | void>[] = [];
+    /**
+     * If doing a multi-part upload, this holds a promise for each part that is currently being
+     * uploaded, so that we can upload several parts in parallel but never more than
+     * `maxConcurrentParts` at once. Each promise removes itself from the set once it has settled.
+     */
+    const partsInFlight = new Set<Promise<void>>();
 
     super({
       start() {}, // required
@@ -49,23 +90,14 @@ export class ObjectUploader extends WritableStream<Uint8Array_> {
         try {
           // We are going to upload this file in a single part, because it's small enough
           if (partNumber == 1 && chunk.length < partSize) {
-            // PUT the chunk in a single request — use an empty query.
-            const response = await client.makeRequest({
-              method,
-              headers: new Headers({
-                // Set user metadata as this is not a multipart upload
-                ...metadata,
-                "Content-Length": String(chunk.length),
-              }),
-              bucketName,
-              objectName,
-              payload: chunk,
-            });
-            result = {
-              etag: sanitizeETag(response.headers.get("etag") ?? undefined),
-              versionId: getVersionId(response.headers),
-            };
+            result = await uploadSingleRequest({ client, bucketName, objectName, metadata, payload: chunk });
             return;
+          }
+          if (partNumber > maxParts) {
+            throw new Error(
+              `Cannot upload more than ${maxParts} parts. If you are uploading a stream of unknown size, ` +
+                `specify its "size" or use a larger "partSize" (currently ${partSize} bytes).`,
+            );
           }
 
           /// If we get here, this is a streaming upload in multiple parts.
@@ -87,7 +119,12 @@ export class ObjectUploader extends WritableStream<Uint8Array_> {
               partHeaders[key] = value;
             }
           }
-          const partPromise = client.makeRequest({
+          // We can't `await` the upload of this part now, because that will cause the uploads to
+          // happen in series instead of parallel. But we don't want to let the promise
+          // throw an exception when we haven't awaited it, because that can cause the
+          // process to crash. So use .catch() to watch for errors and store them in
+          // `multiUploadError` if they occur.
+          const partPromise: Promise<void> = client.makeRequest({
             method,
             query: { partNumber: partNumber.toString(), uploadId },
             headers: new Headers(partHeaders),
@@ -97,19 +134,20 @@ export class ObjectUploader extends WritableStream<Uint8Array_> {
           }).then((response) => {
             // In order to aggregate the parts together, we need to collect the etags.
             etags.push({ part: partNumber, etag: sanitizeETag(response.headers.get("etag") ?? undefined) });
-            return response;
-          });
-          // We can't `await partPromise` now, because that will cause the uploads to
-          // happen in series instead of parallel. But we don't want to let the promise
-          // throw an exception when we haven't awaited it, because that can cause the
-          // process to crash. So use .catch() to watch for errors and store them in
-          // `multiUploadError` if they occur.
-          partsPromises.push(partPromise.catch((err) => {
+          }).catch((err) => {
             // An error occurred when uploading this one part:
             if (!multiUploadError) {
               multiUploadError = err;
             }
-          }));
+          }).finally(() => {
+            partsInFlight.delete(partPromise);
+          });
+          partsInFlight.add(partPromise);
+          // Don't start uploading the next part until one of the parts in flight has finished.
+          // Without this, a large upload would read the whole stream into memory at once.
+          if (partsInFlight.size >= maxConcurrentParts) {
+            await Promise.race(partsInFlight);
+          }
         } catch (err) {
           // Throwing an error will make future writes to this sink fail.
           throw err;
@@ -120,7 +158,7 @@ export class ObjectUploader extends WritableStream<Uint8Array_> {
           // This was already completed, in a single upload. Nothing more to do.
         } else if (uploadId) {
           // Wait for all parts to finish uploading (or fail)
-          await Promise.all(partsPromises);
+          await Promise.all(partsInFlight);
           if (multiUploadError) {
             // One or more parts failed to upload:
             throw multiUploadError;
@@ -130,7 +168,15 @@ export class ObjectUploader extends WritableStream<Uint8Array_> {
           // Complete the multi-part upload
           result = await completeMultipartUpload({ client, bucketName, objectName, uploadId, etags });
         } else {
-          throw new Error("Stream was closed without uploading any data.");
+          // The stream closed without ever producing a chunk, so this is an empty object. S3
+          // supports those, and this is what you get if you upload an empty string/Uint8Array.
+          result = await uploadSingleRequest({
+            client,
+            bucketName,
+            objectName,
+            metadata,
+            payload: new Uint8Array(),
+          });
         }
       },
     });

--- a/transform-chunk-sizes.test.ts
+++ b/transform-chunk-sizes.test.ts
@@ -153,3 +153,30 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "TransformChunkSizes - big chunk size, so the internal buffer has to grow",
+  fn: async () => {
+    // Use an output chunk size much bigger than the amount of data we'll actually get, to check
+    // that the transform grows its internal buffer as needed rather than allocating it up front.
+    const outChunkSize = 40 * 1024 * 1024;
+    const inChunkSize = 100_000;
+    const inChunkCount = 5;
+    const inputStream = new NumberSource(0, inChunkCount, inChunkSize);
+    const outputStream = new DataSink();
+    inputStream.pipeThrough(new TransformChunkSizes(outChunkSize)).pipeTo(outputStream);
+    await outputStream.done;
+
+    // All of the data fits into one (final, partial) chunk:
+    assertEquals(outputStream.outputData.length, 1);
+    const output = outputStream.outputData[0];
+    assertEquals(output.length, inChunkSize * inChunkCount);
+    // And the data is intact: the Nth input chunk was inChunkSize bytes, all set to N.
+    for (let i = 0; i < inChunkCount; i++) {
+      assertEquals(
+        output.subarray(i * inChunkSize, (i + 1) * inChunkSize),
+        new Uint8Array(inChunkSize).fill(i),
+      );
+    }
+  },
+});

--- a/transform-chunk-sizes.ts
+++ b/transform-chunk-sizes.ts
@@ -4,9 +4,10 @@
  */
 export class TransformChunkSizes extends TransformStream<Uint8Array, Uint8Array> {
   constructor(private readonly outChunkSize: number) {
-    // We'll keep one internal buffer of size outChunkSize,
-    // plus a current "offset" telling us how many bytes are in it.
-    let buffer = new Uint8Array(outChunkSize);
+    // We'll keep one internal buffer holding the partial chunk, plus a current "offset" telling us
+    // how many bytes are in it. The buffer starts out empty and grows (up to outChunkSize) as data
+    // arrives, so that a stream much smaller than outChunkSize doesn't allocate the full chunk size.
+    let buffer = new Uint8Array(0);
     let offset = 0;
 
     super({
@@ -18,6 +19,16 @@ export class TransformChunkSizes extends TransformStream<Uint8Array, Uint8Array>
           // How many bytes we can copy from the incoming chunk this iteration
           const toCopy = Math.min(needed, chunk.length - pos);
 
+          if (buffer.length < offset + toCopy) {
+            // Grow the buffer, doubling its size each time so that repeatedly appending small
+            // chunks doesn't mean repeatedly copying the whole buffer.
+            const bigger = new Uint8Array(
+              Math.min(outChunkSize, Math.max(offset + toCopy, buffer.length * 2, 64 * 1024)),
+            );
+            bigger.set(buffer.subarray(0, offset));
+            buffer = bigger;
+          }
+
           // Copy from chunk into our internal buffer
           buffer.set(chunk.subarray(pos, pos + toCopy), offset);
           pos += toCopy;
@@ -27,7 +38,7 @@ export class TransformChunkSizes extends TransformStream<Uint8Array, Uint8Array>
           if (offset === outChunkSize) {
             controller.enqueue(buffer);
             // We must not reuse that buffer, because it's still being read by the controller.
-            buffer = new Uint8Array(outChunkSize);
+            buffer = new Uint8Array(0);
             offset = 0;
           }
         }


### PR DESCRIPTION
This fixes the following issues:

1. A streaming putObject allocates a 528MB buffer before uploading a single byte. When size is unknown, calculatePartSize(undefined) assumed the 5TB max and returns 528MB. This PR changes the default part size to 64MB, which does limit uploads of unknown sizes to 640GB by default - for larger uploads, specify either `size` or `partSize` explicitly.

2. Multipart part uploads had no concurrency limit. Now uploads are limited to 4 concurrent parts.

3. For the very common case of a Uint8Array/string smaller than partSize, we now skip streams entirely and hand the bytes straight to makeRequest, reducing memory usage by avoiding the need to duplicate the data into a stream buffer.

4. Uploading empty files now works correctly, whether using streams or not.